### PR TITLE
Add convenience import opengever.maintenance.dm that points to setup_debug_mode

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,18 +2,21 @@ Introduction
 ============
 
 This product provides some commonly used utility functions and scripts
-for OpenGever maintenance, running `bin/instance run` scripts or tasks
+for OpenGever maintenance, running ``bin/instance run`` scripts or tasks
 done in debug mode.
 
-Get into debug mode
-===================
+Setting up debug mode
+=====================
 
 .. code::
 
     $ bin/instance debug
     ...
-    >>> from opengever.maintenance.debughelpers import setup_plone
-    >>> setup_debug_mode()
+    >>> from opengever.maintenance import dm
+    >>> dm()
     INFO: Using Plone Site 'mandant1'.
     >>> plone
     <PloneSite at /mandant1>
+
+(``opengever.maintenance.dm`` is a convenience import that actually points to
+``opengever.maintenance.debughelpers.setup_debug_mode``.)

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.0 (unreleased)
 ----------------
 
+- Added convenience import opengever.maintenance.dm that points to setup_debug_mode function.
+  [lgraf]
+
 - Added script for mass-checkin of documents checked out by a particular user.
   [lgraf]
 

--- a/opengever/maintenance/__init__.py
+++ b/opengever/maintenance/__init__.py
@@ -1,0 +1,5 @@
+from opengever.maintenance.debughelpers import setup_debug_mode
+
+
+# Convenience shortcut for easier importing
+dm = setup_debug_mode


### PR DESCRIPTION
``` bash
    $ bin/instance debug
```

``` python
    >>> from opengever.maintenance import dm
    >>> dm()
    INFO: Using Plone Site 'mandant1'.
    >>> plone
    <PloneSite at /mandant1>
```
