### PR TITLE
Add helper scripts for running OGDS sync as a cron job.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 1.0 (unreleased)
 ----------------
 
+- Add helper scripts for running OGDS sync as a cron job.
+  (Previously in og-maintenance).
+  [lgraf]
+
 - Add a 'transmogrify' view to run a transmogrifier config TTW.
   [lgraf]
 

--- a/scripts/.config.sh.template
+++ b/scripts/.config.sh.template
@@ -1,0 +1,15 @@
+# This file is required for update-ogds.sh and must be placed
+# at /home/zope/.opengever/.config.sh
+#
+# It must define at least FIRST_CLIENT_PATH and FIRST_CLIENT_ID
+#
+# FIRST_CLIENT_PATH will be used to locate the path to the first
+# client's buildout directory, find bin/instance0 and the path
+# to src/opengever.maintenance
+#
+# FIRST_CLIENT_ID is the ID of the Plone site for the first client.
+#
+# Example:
+
+export FIRST_CLIENT_PATH="/home/zope/host.4teamwork.ch/01-plone-gever-test/"
+export FIRST_CLIENT_ID="mandant1"

--- a/scripts/.profile.sh.template
+++ b/scripts/.profile.sh.template
@@ -1,0 +1,7 @@
+# This file can be used to set environment variables that
+# are required for update-ogds.sh to work properly.
+# For example:
+
+export ORACLE_HOME=/usr/lib/oracle/11.2/client/lib
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$ORACLE_HOME
+

--- a/scripts/start_synchronisation.py
+++ b/scripts/start_synchronisation.py
@@ -1,0 +1,23 @@
+from opengever.ogds.base.ldap_import.sync_ldap import run_import
+from optparse import OptionParser
+
+
+def main():
+    # check if we have a zope environment aka 'app'
+    mod = __import__(__name__)
+    if not ('app' in dir(mod) or 'app' in globals()):
+        print "Must be run with 'bin/instance run'."
+        return
+
+    parser = OptionParser()
+    parser.add_option("-s", "--site-root",
+                      dest="site_root", default=u'/Plone')
+    parser.add_option('-u', "--update-syncstamp",
+                      dest="update_syncstamp", default=True)
+    (options, args) = parser.parse_args()
+
+    run_import(app, options)
+
+if __name__ == '__main__':
+    main()
+

--- a/scripts/update-ogds.sh
+++ b/scripts/update-ogds.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+PROFILE_PATH="/home/zope/.opengever/.profile.sh"
+CONFIG_PATH="/home/zope/.opengever/.config.sh"
+
+if [ -f $PROFILE_PATH ]
+  then
+    echo "Loading site-specific environment from $PROFILE_PATH..."
+    source $PROFILE_PATH
+fi
+
+if [ -f $CONFIG_PATH ]
+  then
+    echo "Loading site-specific configuration from $CONFIG_PATH..."
+    source $CONFIG_PATH
+else
+    echo "ERROR: Configuration not found at $CONFIG_PATH"
+    echo "Please create the file and set configuration variables according"
+    echo "to opengever.maintenance/scripts/.config.sh.template."
+    exit 1
+fi
+
+echo "Updating OGDS used by client '${FIRST_CLIENT_ID}' at '${FIRST_CLIENT_PATH}'..."
+${FIRST_CLIENT_PATH}/bin/instance0 run ${FIRST_CLIENT_PATH}/src/opengever.maintenance/scripts/start_synchronisation.py -s ${FIRST_CLIENT_ID}


### PR DESCRIPTION
This PR includes the scripts `update-ogds.sh` and `start_synchronisation.py` that lived in `og-maintenance` before.

The scripts have been refactored to read site-specific settings from config files rather than hardcode them. For this purpose, two new config files have been introduced:

`~/.opengever/.profile.sh`:
**Optional**. May contain site-specific environment variables that need to be set in order for `update-ogds.sh` to work.

`~/.opengever/.config.sh`:
**Required**. Must at least define `FIRST_CLIENT_PATH` and `FIRST_CLIENT_ID`.

See the included [`.profile.sh.template`](https://github.com/4teamwork/opengever.maintenance/blob/lg-ogds-sync/scripts/.profile.sh.template) and [`.config.sh.template`](https://github.com/4teamwork/opengever.maintenance/blob/lg-ogds-sync/scripts/.config.sh.template) for examples how these should look.
