### PR TITLE
Add a @@health-check view to be used with httpok and/or HAProxy.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.0 (unreleased)
 ----------------
 
+- Add a @@health-check view to be used with httpok and/or HAProxy.
+  [lgraf]
+
 - Add view to list principals used in role assignments.
   [lgraf]
 

--- a/opengever/maintenance/browser/health_check.py
+++ b/opengever/maintenance/browser/health_check.py
@@ -1,0 +1,27 @@
+from five import grok
+from opengever.base.model import create_session
+from Products.CMFPlone.interfaces import IPloneSiteRoot
+import json
+
+
+class HealthCheckView(grok.View):
+    """Health check view to be used by superlance httpok plugin and/or
+    HAProxy to determine whether an instance is in a healthy state.
+
+    WARNING: Keep this cheap, because
+    1) it will be called regularly
+    2) it's protected with zope.Public -> accessible for Anonymous users
+    """
+
+    grok.name('health-check')
+    grok.context(IPloneSiteRoot)
+    grok.require('zope.Public')
+
+    def render(self):
+        # Access the session in order to trigger a possible
+        # 'MySQL server has gone away' error
+        session = create_session()
+        session.execute('SELECT 1')
+
+        result = dict(status='OK')
+        return json.dumps(result)


### PR DESCRIPTION
This adds a `@@health-check` view on the Plone site root that can be used to determine whether an instance is in a healthy state or not.

- This view is public and will be called regularly, so it needs to be cheap! Keep this in mind when changing it.
- Currently it just does a `SELECT 1` on the SQL connection, in order to trigger a potential `MySQL server has gone away`

@phgross 