### PR TITLE
Use zope2.Public to protect the @@health-check view.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.0 (unreleased)
 ----------------
 
+- Use zope2.Public for the @@health-check view.
+  [lgraf]
+
 - Add a @@health-check view to be used with httpok and/or HAProxy.
   [lgraf]
 

--- a/opengever/maintenance/browser/health_check.py
+++ b/opengever/maintenance/browser/health_check.py
@@ -15,7 +15,7 @@ class HealthCheckView(grok.View):
 
     grok.name('health-check')
     grok.context(IPloneSiteRoot)
-    grok.require('zope.Public')
+    grok.require('zope2.Public')
 
     def render(self):
         # Access the session in order to trigger a possible


### PR DESCRIPTION
`zope.Public` apparently doesn't work.

@phgross @bierik 