### PR TITLE
Use conditional import in @@health-check view to make it work for og.core < 4.2.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 1.0 (unreleased)
 ----------------
 
+- Use conditional import in @@health-check view to
+  make it work for og.core < 4.2.
+  [lgraf]
+
 - Use zope2.Public for the @@health-check view.
   [lgraf]
 

--- a/opengever/maintenance/browser/health_check.py
+++ b/opengever/maintenance/browser/health_check.py
@@ -1,7 +1,12 @@
 from five import grok
-from opengever.base.model import create_session
 from Products.CMFPlone.interfaces import IPloneSiteRoot
 import json
+
+try:
+    from opengever.base.model import create_session
+except ImportError:
+    # opengever.core < 4.2
+    from opengever.ogds.base.utils import create_session
 
 
 class HealthCheckView(grok.View):


### PR DESCRIPTION
`create_session` was moved from `opengever.ogds.base.utils` to `opengever.base.model` in `opengever.core >= 4.2`. This conditional import makes sure `opengever.maintenance` works with all deployed versions of `opengever.core`.

@phgross @deiferni 