### PR TITLE
Adjust imports for Plone 4.3 support.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.0 (unreleased)
 ----------------
 
+- Adjust imports for Plone 4.3 support.
+  [phgross]
+
 - Add script to list (possibly) truncated rows in SQL.
   [lgraf]
 

--- a/opengever/maintenance/debughelpers.py
+++ b/opengever/maintenance/debughelpers.py
@@ -2,8 +2,9 @@ from AccessControl.SecurityManagement import newSecurityManager
 from optparse import OptionParser
 from Products.CMFPlone.Portal import PloneSite
 from Testing.makerequest import makerequest
-from zope.app.component.hooks import setSite
+from zope.component.hooks import setSite
 import sys
+
 
 MAX_FRAMES = 5
 

--- a/opengever/maintenance/scripts/check_relations.py
+++ b/opengever/maintenance/scripts/check_relations.py
@@ -2,8 +2,8 @@ from AccessControl.SecurityManagement import newSecurityManager
 from optparse import OptionParser
 from Testing.makerequest import makerequest
 from zc.relation.interfaces import ICatalog
-from zope.app.component.hooks import setSite
 from zope.component import getUtility
+from zope.component.hooks import setSite
 import transaction
 
 
@@ -63,4 +63,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-


### PR DESCRIPTION
Gemäss den Änderungen in https://github.com/4teamwork/opengever.core/pull/982, müssen wir auch im opengever.maintenance die Imports für die Plone 4.3 Kompatibilität anpassen.

@deiferni @lukasgraf 