### PR TITLE
Declare missing dependencies

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.0 (unreleased)
 ----------------
 
+- Declare dependency on five.grok so that z3c.autoinclude loads its ZCML.
+  [lgraf]
+
 - Adjust imports for Plone 4.3 support.
   [phgross]
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -8,6 +8,9 @@ Changelog
 - Declare dependency on five.grok so that z3c.autoinclude loads its ZCML.
   [lgraf]
 
+- Declare dependency on plone.api.
+  [lgraf]
+
 - Adjust imports for Plone 4.3 support.
   [phgross]
 

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(name='opengever.maintenance',
       install_requires=[
           'setuptools',
           'Plone',
+          'five.grok',
           'apachelog',
       ],
       entry_points="""

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(name='opengever.maintenance',
           'setuptools',
           'Plone',
           'five.grok',
+          'plone.api',
           'apachelog',
       ],
       entry_points="""


### PR DESCRIPTION
There were at least two dependencies missing from `opengever.maintenance`:

- `plone.api` is used by some views. We didn't include this in older versions of `opengever.core`, so since we use it here, we need to declare it.
- The ZCML of `five.grok` needs to be loaded for the template registration with `grokcore.view` to work. So we include the dependency on `five.grok`, then `z3c.autoinclude` will load the ZCML for `five.grok` automatically.

There's a bunch of other dependencies that *should* be specified, but they're not critical at the moment - in reality, we **always** use `opengever.maintenance` with `opengever.core`, so those dependencies are there. 

@phgross @deiferni 