### PR TITLE
Add testing setup to test against supported versions of opengever.core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,16 @@
 *.pyc
 *.pyo
 *.mo
+.installed.cfg
+.mr.developer.cfg
+bin/
+build/
+buildout.cfg
+coverage/
+develop-eggs/
+dist/
+eggs/
+parts/
+src/
+var/
+snakefood/

--- a/base-testing.cfg
+++ b/base-testing.cfg
@@ -1,0 +1,15 @@
+[buildout]
+extends =
+    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/authentication.cfg
+
+find-links =
+    http://pypi.python.org/
+    http://psc.4teamwork.ch/simple
+
+[test]
+arguments = ['-s', '${buildout:package-namespace}', '--exit-with-status', '--auto-color', '--auto-progress', '--xml', '--package-path', '${buildout:directory}/${buildout:package-namespace}', '${buildout:package-namespace}']
+eggs += opengever.core
+
+[versions]
+opengever.maintenance =
+ftw.testing =

--- a/opengever/maintenance/testing.py
+++ b/opengever/maintenance/testing.py
@@ -1,0 +1,21 @@
+from ftw.testing.layer import COMPONENT_REGISTRY_ISOLATION
+from plone.app.testing import IntegrationTesting
+from plone.app.testing import PloneSandboxLayer
+from zope.configuration import xmlconfig
+
+
+class OGMaintenanceLayer(PloneSandboxLayer):
+
+    defaultBases = (COMPONENT_REGISTRY_ISOLATION,)
+
+    def setUpZope(self, app, configurationContext):
+        import opengever.maintenance
+        xmlconfig.file('configure.zcml', opengever.maintenance,
+                       context=configurationContext)
+
+OG_MAINTENANCE_FIXTURE = OGMaintenanceLayer()
+
+OG_MAINTENANCE_INTEGRATION = IntegrationTesting(
+    bases=(OG_MAINTENANCE_FIXTURE,
+           COMPONENT_REGISTRY_ISOLATION),
+    name='opengever.maintenance:integration')

--- a/opengever/maintenance/tests/test_grokking.py
+++ b/opengever/maintenance/tests/test_grokking.py
@@ -1,0 +1,18 @@
+from opengever.maintenance.testing import OG_MAINTENANCE_INTEGRATION
+import unittest2
+
+
+class TestZCML(unittest2.TestCase):
+
+    layer = OG_MAINTENANCE_INTEGRATION
+
+    def test_zcml_loading(self):
+        """Load the ZCML for the opengever.maintenance package in order to
+        trigger any import errors that would prevent the instance from booting.
+        """
+
+        self.layer['load_zcml_string']("""
+            <configure>
+                <include package="opengever.maintenance" />
+            </configure>
+        """)

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,13 @@ import os
 
 version = '1.0dev'
 
+tests_require = [
+    'ftw.testing',
+    'plone.app.testing',
+    'plone.testing',
+    'zope.testing',
+]
+
 setup(name='opengever.maintenance',
       version=version,
       description="Commonly used utilities and scripts for OG maintenance.",
@@ -29,6 +36,8 @@ setup(name='opengever.maintenance',
           'plone.api',
           'apachelog',
       ],
+      tests_require=tests_require,
+      extras_require=dict(tests=tests_require),
       entry_points="""
       # -*- Entry points: -*-
       [z3c.autoinclude.plugin]

--- a/test-og-2.7.x.cfg
+++ b/test-og-2.7.x.cfg
@@ -1,0 +1,8 @@
+[buildout]
+extends =
+    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.2.x.cfg
+    http://kgs.4teamwork.ch/release/opengever/2.7.6
+    base-testing.cfg
+
+package-name = opengever.maintenance
+package-namespace = opengever

--- a/test-og-2.8.x.cfg
+++ b/test-og-2.8.x.cfg
@@ -1,0 +1,8 @@
+[buildout]
+extends =
+    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.2.x.cfg
+    http://kgs.4teamwork.ch/release/opengever/2.8.2
+    base-testing.cfg
+
+package-name = opengever.maintenance
+package-namespace = opengever

--- a/test-og-2.9.x.cfg
+++ b/test-og-2.9.x.cfg
@@ -1,0 +1,8 @@
+[buildout]
+extends =
+    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.2.x.cfg
+    http://kgs.4teamwork.ch/release/opengever/2.9.2
+    base-testing.cfg
+
+package-name = opengever.maintenance
+package-namespace = opengever

--- a/test-og-3.0.x.cfg
+++ b/test-og-3.0.x.cfg
@@ -1,0 +1,8 @@
+[buildout]
+extends =
+    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.2.x.cfg
+    http://kgs.4teamwork.ch/release/opengever/3.0.5
+    base-testing.cfg
+
+package-name = opengever.maintenance
+package-namespace = opengever

--- a/test-og-3.1.x.cfg
+++ b/test-og-3.1.x.cfg
@@ -1,0 +1,8 @@
+[buildout]
+extends =
+    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.2.x.cfg
+    http://kgs.4teamwork.ch/release/opengever/3.1
+    base-testing.cfg
+
+package-name = opengever.maintenance
+package-namespace = opengever

--- a/test-og-3.2.x.cfg
+++ b/test-og-3.2.x.cfg
@@ -1,0 +1,8 @@
+[buildout]
+extends =
+    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.2.x.cfg
+    http://kgs.4teamwork.ch/release/opengever/3.2
+    base-testing.cfg
+
+package-name = opengever.maintenance
+package-namespace = opengever

--- a/test-og-3.3.x.cfg
+++ b/test-og-3.3.x.cfg
@@ -1,0 +1,8 @@
+[buildout]
+extends =
+    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.2.x.cfg
+    http://kgs.4teamwork.ch/release/opengever/3.3.1
+    base-testing.cfg
+
+package-name = opengever.maintenance
+package-namespace = opengever

--- a/test-og-develop.cfg
+++ b/test-og-develop.cfg
@@ -1,0 +1,16 @@
+[buildout]
+
+extends =
+    https://raw.githubusercontent.com/4teamwork/opengever.core/master/sources.cfg
+    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
+    http://kgs.4teamwork.ch/release/opengever/develop
+    base-testing.cfg
+
+package-name = opengever.maintenance
+package-namespace = opengever
+
+auto-checkout -=
+    opengever.maintenance
+
+auto-checkout +=
+    opengever.core


### PR DESCRIPTION
This adds a basic testing setup to test against the currently supported versions of `opengever.core`:

- `2.7`
- `2.8`
- `2.9`
- `3.0`
- `3.1`
- `3.2`
- `3.3`
- `develop`

Also includes a simple testing layer based on the `COMPONENT_REGISTRY_ISOLATION` layer that loads the ZCML for `opengever.maintenance` to trigger any import errors that would prevent the instance from booting.

Many of these tests will currently **fail** because we haven't yet addressed the problems they're supposed to uncover. 