### PR TITLE
Restore compatibility with all supported og.core versions

### DIFF
--- a/opengever/maintenance/compat.py
+++ b/opengever/maintenance/compat.py
@@ -1,0 +1,25 @@
+"""
+Compatibility module to help support all relevant versions of opengever.core
+"""
+
+
+def get_site_url():
+    """Compatibility function to retrieve the `site_url` for the current
+    admin_unit (>= 3.0) or client (< 3.0).
+    """
+    try:
+        # >= 3.0
+        from opengever.ogds.base.utils import get_current_admin_unit
+        site_url = get_current_admin_unit().site_url
+    except ImportError:
+        # 2.7 - 2.9
+        from opengever.ogds.base.utils import get_client_id
+        from opengever.ogds.base.interfaces import IContactInformation
+        from zope.component import getUtility
+
+        client_id = get_client_id()
+        info = getUtility(IContactInformation)
+        client = info.get_client_by_id(client_id)
+        site_url = client.site_url
+
+    return site_url

--- a/opengever/maintenance/pdf_conversion/helpers.py
+++ b/opengever/maintenance/pdf_conversion/helpers.py
@@ -29,6 +29,7 @@ def in_status(status_list):
 
 
 def get_status(doc):
+    # Inline imports to avoid import errors that prevent instance startup
     from opengever.pdfconverter.behaviors.preview import IPreview
     from opengever.pdfconverter.behaviors.preview import CONVERSION_STATE_READY
     from opengever.pdfconverter.behaviors.preview import CONVERSION_STATE_FAILED

--- a/opengever/maintenance/pdf_conversion/helpers.py
+++ b/opengever/maintenance/pdf_conversion/helpers.py
@@ -2,11 +2,12 @@
 """
 
 from Acquisition import aq_inner
-from opengever.ogds.base.utils import get_current_admin_unit
 from Products.CMFCore.utils import getToolByName
 from ZODB.POSException import ConflictError
 import hashlib
 import time
+
+from opengever.maintenance.compat import get_site_url
 
 
 def has_file(doc):
@@ -168,9 +169,9 @@ class PDFConverter(object):
     def get_internal_url(self, context):
         """Build the internal URL of an object.
         """
-        admin_unit_url = get_current_admin_unit().site_url
+        site_url = get_site_url()
         portal_url = getToolByName(context, "portal_url")
-        internal_url = context.absolute_url().replace(portal_url(), admin_unit_url)
+        internal_url = context.absolute_url().replace(portal_url(), site_url)
         return internal_url
 
     def queue_conversion_job(self, doc):

--- a/opengever/maintenance/scripts/convert_pdfs.py
+++ b/opengever/maintenance/scripts/convert_pdfs.py
@@ -1,3 +1,4 @@
+from collections import Counter
 from opengever.maintenance.debughelpers import setup_app
 from opengever.maintenance.debughelpers import setup_option_parser
 from opengever.maintenance.debughelpers import setup_plone
@@ -9,12 +10,6 @@ from zope.component import getUtility
 import random
 import sys
 import transaction
-
-
-try:
-    from collections import Counter
-except ImportError:
-    from opengever.maintenance.utils import Counter
 
 
 # Print a warning message if more than batch_size * WARNING_FACTOR PDFs need

--- a/opengever/maintenance/scripts/convert_pdfs.py
+++ b/opengever/maintenance/scripts/convert_pdfs.py
@@ -2,8 +2,6 @@ from collections import Counter
 from opengever.maintenance.debughelpers import setup_app
 from opengever.maintenance.debughelpers import setup_option_parser
 from opengever.maintenance.debughelpers import setup_plone
-from opengever.pdfconverter.behaviors.preview import CONVERSION_STATE_CONVERTING
-from opengever.pdfconverter.behaviors.preview import IPreview
 from opengever.pdfconverter.interfaces import IPDFConverterSettings
 from plone.registry.interfaces import IRegistry
 from zope.component import getUtility
@@ -68,6 +66,10 @@ class PDFConversionManager(object):
         """Queue PDF conversion jobs for as many documents (that don't have a
         preview PDF yet) as specified by the --batch-size option.
         """
+
+        # Inline imports to avoid import errors that prevent instance startup
+        from opengever.pdfconverter.behaviors.preview import CONVERSION_STATE_CONVERTING
+        from opengever.pdfconverter.behaviors.preview import IPreview
 
         brains = self.portal.portal_catalog(
                                 portal_type="opengever.document.document")

--- a/test_all.sh
+++ b/test_all.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+#
+# Helper script to LOCALLY test opengever.maintenance with all test-*.cfgs
+
+PYTHON="python2.7"
+
+for CFG in test-og-*
+do
+    echo "Testing against ${CFG}..."
+    rm -f ./buildout.cfg
+    ln -s ${CFG} buildout.cfg
+    ${PYTHON} bootstrap.py
+    bin/buildout
+    bin/test
+    echo
+done


### PR DESCRIPTION
This PR introduces a `compat` module that should be used for all conditional imports, compatibility hacks etc... to ensure the `opengever.maintenance` package is compatible with all supported versions of `opengever.core`.

"Compatible" in this context means that it doesn't produce errors (like `ImportErrors` or other ZCML/Grok related errors) **on startup** that would result in the instance not booting. Whether or not it's worth to make the actual *functionality* compatible with all versions will have to be determined on a case-by-case basis.

@deiferni @phgross