### PR TITLE
Fix bin/instance run for recent plone.recipe.zope2instance versions

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,11 @@ Changelog
 1.0 (unreleased)
 ----------------
 
+- Add a fake '-c' option to work around an issue with recent versions of
+  plone.recipe.zope2instance's bin/interpreter script.
+  See https://dev.plone.org/ticket/13414
+  [lgraf]
+
 - Declare dependency on five.grok so that z3c.autoinclude loads its ZCML.
   [lgraf]
 

--- a/opengever/maintenance/debughelpers.py
+++ b/opengever/maintenance/debughelpers.py
@@ -106,6 +106,11 @@ def setup_option_parser():
     parser.
     """
     parser = OptionParser()
+    # Add a fake '-c' option to work around an issue with recent versions of
+    # plone.recipe.zope2instance's bin/interpreter script.
+    # See https://dev.plone.org/ticket/13414
+    parser.add_option("-c", "--fake-option", dest="fake_option", default=None)
+
     parser.add_option("-s", "--site-root", dest="site_root", default=None)
     parser.add_option("-v", "--verbose", action="store_true", dest="verbose",
                       default=False)


### PR DESCRIPTION
Add a fake `-c` option to work around an issue with recent versions of `plone.recipe.zope2instance`'s `bin/interpreter` script.

The `bin/interpreter` script fails at argument parsing and passes a `-c` to the argument parser of `bin/instance run` scripts.

See https://dev.plone.org/ticket/13414 for details.
@deiferni @phgross 