### PR TITLE
Pin down `collective.recipe.template` for tests.

### DIFF
--- a/base-testing.cfg
+++ b/base-testing.cfg
@@ -13,3 +13,6 @@ eggs += opengever.core
 [versions]
 opengever.maintenance =
 ftw.testing =
+
+# compatibility with zc.buildout 1.4
+collective.recipe.template = 1.11


### PR DESCRIPTION
Because the newest version (1.12) of collective.recipe.template, in particular this PR, breaks compatibility for zc.buildout 1.4.
