### PR TITLE
Add script for catalog and ZODB object stats

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 1.0 (unreleased)
 ----------------
 
+- Add a get_object_count() function that returns the number of ZODB objects
+  and can also handle RelStorage + Oracle.
+  [lgraf]
+
 - Add script to update the PW for a user in the ZODBUserManager.
   [lgraf]
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 1.0 (unreleased)
 ----------------
 
+- Add a script that collects object stats from catalog and ZODB and
+  returns them as JSON.
+  [lgraf]
+
 - Add get_contenttype_stats() function that returns counts for
   common GEVER content types from ZCatalog.
   [lgraf]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 1.0 (unreleased)
 ----------------
 
+- Add get_contenttype_stats() function that returns counts for
+  common GEVER content types from ZCatalog.
+  [lgraf]
+
 - Add a get_object_count() function that returns the number of ZODB objects
   and can also handle RelStorage + Oracle.
   [lgraf]

--- a/opengever/maintenance/scripts/obj_stats.py
+++ b/opengever/maintenance/scripts/obj_stats.py
@@ -1,0 +1,48 @@
+"""
+Script that dumps a JSON with statistics about counts for common
+GEVER content types and total number of ZODB objects.
+"""
+
+from opengever.maintenance.debughelpers import setup_app
+from opengever.maintenance.debughelpers import setup_option_parser
+from opengever.maintenance.debughelpers import setup_plone
+from opengever.maintenance.stats.catalog import get_contenttype_stats
+from opengever.maintenance.stats.zodb import get_object_count
+import json
+
+
+def get_zodb_stats(plone):
+    db = plone._p_jar.db()
+    obj_count = get_object_count(db)
+    return {'zodb_objects': obj_count}
+
+
+def get_catalog_stats(plone):
+    catalog_stats = get_contenttype_stats(plone)
+    return catalog_stats
+
+
+def get_stats(plone):
+    stats = {plone.id: {}}
+
+    catalog_stats = get_catalog_stats(plone)
+    zodb_stats = get_zodb_stats(plone)
+
+    stats[plone.id].update(catalog_stats)
+    stats[plone.id].update(zodb_stats)
+    return stats
+
+
+def main():
+    app = setup_app()
+
+    parser = setup_option_parser()
+    (options, args) = parser.parse_args()
+
+    plone = setup_plone(app, options)
+    stats = get_stats(plone)
+    print json.dumps(stats)
+
+
+if __name__ == '__main__':
+    main()

--- a/opengever/maintenance/stats/catalog.py
+++ b/opengever/maintenance/stats/catalog.py
@@ -1,19 +1,27 @@
 from ftw.mail.mail import IMail
+from opengever.contact.contact import IContact
 from opengever.document.behaviors import IBaseDocument
+from opengever.document.document import IDocumentSchema
 from opengever.dossier.behaviors.dossier import IDossierMarker
+from opengever.inbox.forwarding import IForwarding
 from opengever.repository.interfaces import IRepositoryFolder
 from opengever.repository.repositoryroot import IRepositoryRoot
 from opengever.task.task import ITask
+from opengever.tasktemplates.content.tasktemplate import ITaskTemplate
 from plone import api
 
 
 TYPES = {
-    'dossier': IDossierMarker,
-    'document': IBaseDocument,
-    'mail': IMail,
-    'task': ITask,
-    'repositoryfolder': IRepositoryFolder,
-    'repositoryroot': IRepositoryRoot,
+    'dossiers': IDossierMarker,
+    'documents': IDocumentSchema,
+    'mails': IMail,
+    'base_documents': IBaseDocument,
+    'tasks': ITask,
+    'repositoryfolders': IRepositoryFolder,
+    'repositoryroots': IRepositoryRoot,
+    'tasktemplates': ITaskTemplate,
+    'contacts': IContact,
+    'forwardings': IForwarding,
 }
 
 

--- a/opengever/maintenance/stats/catalog.py
+++ b/opengever/maintenance/stats/catalog.py
@@ -1,0 +1,27 @@
+from ftw.mail.mail import IMail
+from opengever.document.behaviors import IBaseDocument
+from opengever.dossier.behaviors.dossier import IDossierMarker
+from opengever.repository.interfaces import IRepositoryFolder
+from opengever.repository.repositoryroot import IRepositoryRoot
+from opengever.task.task import ITask
+from plone import api
+
+
+TYPES = {
+    'dossier': IDossierMarker,
+    'document': IBaseDocument,
+    'mail': IMail,
+    'task': ITask,
+    'repositoryfolder': IRepositoryFolder,
+    'repositoryroot': IRepositoryRoot,
+}
+
+
+def get_contenttype_stats(plone):
+    catalog_stats = {}
+    catalog = api.portal.get_tool('portal_catalog')
+    for type_key, iface in TYPES.items():
+        brains = catalog.unrestrictedSearchResults(
+            object_provides=iface.__identifier__)
+        catalog_stats[type_key] = len(brains)
+    return catalog_stats

--- a/opengever/maintenance/stats/zodb.py
+++ b/opengever/maintenance/stats/zodb.py
@@ -1,0 +1,54 @@
+import pkg_resources
+
+try:
+    pkg_resources.get_distribution('RelStorage')
+except pkg_resources.DistributionNotFound:
+    HAS_RELSTORAGE = False
+else:
+    HAS_RELSTORAGE = True
+    from relstorage.storage import RelStorage
+    from relstorage.adapters.stats import OracleStats
+
+
+def get_object_count(db):
+    """Returns the number of objects in the ZODB
+    """
+
+    count = db.objectCount()
+    if count != 0:
+        return count
+
+    # Might be RelStorage with Oracle, where object count is approximate and
+    # therefore has been disabled for the time being.
+    if HAS_RELSTORAGE:
+        if isinstance(db.storage, RelStorage):
+            stats = db.storage._adapter.stats
+            if isinstance(stats, OracleStats):
+                return _get_object_count_oracle(stats.connmanager)
+
+    return 0
+
+
+def _get_object_count_oracle(connmanager):
+    """Returns the number of objects in the database.
+
+    See relstorage.adapters.stats.OracleStats @2df8f8df
+    """
+
+    conn, cursor = connmanager.open(
+        connmanager.isolation_read_only)
+    try:
+        stmt = """
+        SELECT NUM_ROWS
+        FROM USER_TABLES
+        WHERE TABLE_NAME = 'CURRENT_OBJECT'
+        """
+        cursor.execute(stmt)
+        res = cursor.fetchone()[0]
+        if res is None:
+            res = 0
+        else:
+            res = int(res)
+        return res
+    finally:
+        connmanager.close(conn, cursor)


### PR DESCRIPTION
Includes the necessary functions and a script that collects object stats from catalog and ZODB returns them as JSON.

Example output:

```json
{
  "fd": {
    "mails": 5,
    "repositoryfolders": 76,
    "documents": 34,
    "contacts": 3,
    "forwardings": 1,
    "zodb_objects": 12577,
    "tasks": 2,
    "tasktemplates": 1,
    "dossiers": 13,
    "repositoryroots": 1,
    "base_documents": 39
  }
}
```

@phgross @deiferni 