### PR TITLE
Add a script that set a shared secret in the acl_users session management.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.0 (unreleased)
 ----------------
 
+- Add a script that set a shared secret in the acl_users session management.
+  [phgross]
+
 - Add a script that collects object stats from catalog and ZODB and
   returns them as JSON.
   [lgraf]

--- a/opengever/maintenance/scripts/set_shared_secret.py
+++ b/opengever/maintenance/scripts/set_shared_secret.py
@@ -1,0 +1,39 @@
+from opengever.maintenance.debughelpers import setup_app
+from opengever.maintenance.debughelpers import setup_plone
+from opengever.maintenance.debughelpers import setup_option_parser
+import sys
+import transaction
+
+
+USAGE = """\
+Usage: bin/instance run set_shared_secret.py <shared_secret>
+"""
+
+SEPARATOR = '-' * 78
+
+
+def set_shared_secret(plone, secret):
+    acl_users = plone.acl_users
+    acl_users.session._shared_secret = secret
+
+    transaction.commit()
+    print "Shared secret successfully set."
+
+def main():
+    app = setup_app()
+    parser = setup_option_parser()
+    (options, args) = parser.parse_args()
+
+    if not len(args) == 1:
+        print USAGE
+        print "Error: Incorrect number of arguments"
+        sys.exit(1)
+
+    secret = args[0]
+    plone = setup_plone(app, options)
+    set_shared_secret(plone, secret)
+    print SEPARATOR
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Kann nützlich sein um bei einem Mandantenverbund für alle ein `shared_secret` hinterlegen will. 

Funktioniert gleich wie die [`manage_setSharedSecret`](https://github.com/plone/plone.session/blob/master/plone/session/plugins/session.py#L305) Methode, welche vom ZMI angesteuert wird.

@lukasgraf @deiferni 