### PR TITLE
Add scripts to fix mail migrations.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 1.0 (unreleased)
 ----------------
 
+- Add scripts to fix mail-class migrations based on catalog entries
+  and references from the intid utility.
+  [deiferni]
+
 - Add script to fix affected indices with inconsistencies between lexicon and index.
   [deiferni]
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.0 (unreleased)
 ----------------
 
+- Add script to find uncatalogued mails.
+  [deiferni]
+
 - Add scripts to fix mail-class migrations based on catalog entries
   and references from the intid utility.
   [deiferni]

--- a/opengever/maintenance/scripts/find_uncatalogued_mails.py
+++ b/opengever/maintenance/scripts/find_uncatalogued_mails.py
@@ -1,0 +1,47 @@
+"""
+An bin/instance run script to find mails that are not cataloged.
+
+bin/instance0 run find_uncatalogued_mails.py
+"""
+
+from ftw.mail.mail import IMail
+from opengever.maintenance.debughelpers import setup_app
+from opengever.maintenance.debughelpers import setup_plone
+
+
+def recursive_find_uncatalogued_mails(parent, catalog, max_depth=None, depth=0):
+    """Recursively traverse content starting at parent and find
+    uncatalogued mails.
+    """
+
+    if max_depth and depth > max_depth:
+        return
+    if not hasattr(parent, 'objectItems'):
+        return
+
+    try:
+        items = parent.objectItems()
+    except:
+        return
+
+    for ident, item in items:
+        if IMail.providedBy(item):
+            path = '/'.join(item.getPhysicalPath())
+            nof_results = len(catalog.unrestrictedSearchResults({'path': path}))
+            if nof_results != 1:
+                print "{} result(s) for: {}".format(nof_results, path)
+        recursive_find_uncatalogued_mails(item, catalog,
+                                          max_depth=max_depth, depth=depth+1)
+
+
+def main():
+    plone = setup_plone(setup_app())
+    roots = plone.portal_catalog.unrestrictedSearchResults(
+        {'portal_type': ['opengever.repository.repositoryroot']})
+    for root in roots:
+        print 'checking repository {}'.format(root.id)
+        recursive_find_uncatalogued_mails(root, plone.portal_catalog)
+
+
+if __name__ == '__main__':
+    main()

--- a/opengever/maintenance/scripts/fix_mail_class_intids.py
+++ b/opengever/maintenance/scripts/fix_mail_class_intids.py
@@ -1,0 +1,105 @@
+"""
+A bin/instance run script which checks and fixes the class of
+all mail objects that are references from the intid catalog.
+
+bin/instance0 run fix_mail_class_intids.py
+"""
+
+from Acquisition import aq_base
+from Acquisition import aq_parent
+from ftw.mail.mail import Mail
+from opengever.mail.mail import OGMail
+from opengever.maintenance.debughelpers import setup_app
+from opengever.maintenance.debughelpers import setup_plone
+from Products.BTreeFolder2.BTreeFolder2 import BTreeFolder2Base
+from zope.app.intid.interfaces import IIntIds
+from zope.component import getUtility
+from zope.interface import directlyProvidedBy
+from zope.interface import directlyProvides
+import transaction
+
+
+def find_key_references_with_wrong_class(intids):
+    wrong_ids = [keyref for keyref in intids.ids
+                 if keyref.object.__class__ == Mail]
+    wrong_refs = [keyref for keyref in intids.refs.values()
+                  if keyref.object.__class__ == Mail]
+    assert set(wrong_ids) == set(wrong_refs)
+
+    return wrong_refs
+
+
+def fix_intids(intids, mail):
+    """Fix reference in intids btree and keyreference objects.
+    """
+
+    intid = intids.getId(mail)
+    reference_to_persistent = intids.refs[intid]
+
+    del intids.refs[intid]
+    del intids.ids[reference_to_persistent]
+
+    intids.refs[intid] = reference_to_persistent
+    intids.ids[reference_to_persistent] = intid
+
+    reference_to_persistent._p_changed = True
+    return intid
+
+
+def fix_mail_class(plone):
+    catalog = plone.portal_catalog
+    intids = getUtility(IIntIds)
+
+    wrong_refs = find_key_references_with_wrong_class(intids)
+    print '{} wrong references in intid utility'.format(len(wrong_refs))
+
+    for reference in wrong_refs:
+        unwrapped_mail = reference.object
+
+        # query mail from catalog for correct acquisition wrapping
+        brains = catalog.unrestrictedSearchResults(UID=unwrapped_mail.UID())
+        if len(brains) < 1:
+            # some mails seem to be stuck in the intid catalog but cannot be
+            # accessed otherwise. Also migrate them to be on the safe side.
+            unwrapped_mail.__class__ = OGMail
+            unwrapped_mail._ofs_migrated = True
+            unwrapped_mail._p_changed = True
+            fix_intids(intids, unwrapped_mail)
+            continue
+
+        mail = brains[0].getObject()
+        # copied from ftw.upgrade.step.migrate_class
+        mail.__class__ = OGMail
+        base = aq_base(mail)
+        base._ofs_migrated = True
+        base._p_changed = True
+
+        parent = aq_base(aq_parent(mail))
+        id_ = base.getId()
+
+        # fix entry in parent's btree
+        if isinstance(parent, BTreeFolder2Base):
+            del parent._tree[id_]
+            parent._tree[id_] = base
+        else:
+            parent._p_changed = True
+
+        intid = fix_intids(intids, mail)
+
+        # Refresh provided interfaces cache
+        directlyProvides(base, directlyProvidedBy(base))
+        mail.reindexObject()
+
+        print 'Mail {}:{} fixed new class: {}'.format(mail, intid, mail.__class__)
+        print '/'.join(mail.getPhysicalPath())
+
+    transaction.commit()
+
+
+def main():
+    plone = setup_plone(setup_app())
+    fix_mail_class(plone)
+
+
+if __name__ == '__main__':
+    main()

--- a/opengever/maintenance/scripts/fix_mail_class_query.py
+++ b/opengever/maintenance/scripts/fix_mail_class_query.py
@@ -1,0 +1,85 @@
+"""
+A bin/instance run script which checks and fixes the class of
+all mail objects based on querying the catalog.
+
+bin/instance0 run fix_mail_class_query.py
+"""
+
+from Acquisition import aq_base
+from Acquisition import aq_parent
+from ftw.mail.mail import Mail
+from opengever.mail.mail import OGMail
+from opengever.maintenance.debughelpers import setup_app
+from opengever.maintenance.debughelpers import setup_plone
+from Products.BTreeFolder2.BTreeFolder2 import BTreeFolder2Base
+from zope.app.intid.interfaces import IIntIds
+from zope.component import getUtility
+from zope.interface import directlyProvidedBy
+from zope.interface import directlyProvides
+import transaction
+
+
+def fix_mail_class(plone):
+    catalog = plone.portal_catalog
+    intids = getUtility(IIntIds)
+
+    counter = 0
+    mails_to_fix = []
+
+    mails = catalog.unrestrictedSearchResults(
+        {"portal_type": 'ftw.mail.mail'})
+
+    for brain in mails:
+        mail = brain.getObject()
+        if mail.__class__.__name__ != 'OGMail':
+            assert mail.__class__ == Mail
+            counter = counter + 1
+            mails_to_fix.append(mail)
+
+    print '{} / {} with wrong class queried'.format(counter, len(mails))
+
+    for mail in mails_to_fix:
+        # copied from ftw.upgrade.step.migrate_class
+        mail.__class__ = OGMail
+        base = aq_base(mail)
+        base._ofs_migrated = True
+        base._p_changed = True
+
+        parent = aq_base(aq_parent(mail))
+        id_ = base.getId()
+
+        # fix entry in parent's btree
+        if isinstance(parent, BTreeFolder2Base):
+            del parent._tree[id_]
+            parent._tree[id_] = base
+        else:
+            parent._p_changed = True
+
+        # fix reference in intids btree and keyreference object
+        intid = intids.getId(mail)
+        reference_to_persistent = intids.refs[intid]
+
+        del intids.refs[intid]
+        del intids.ids[reference_to_persistent]
+
+        intids.refs[intid] = reference_to_persistent
+        intids.ids[reference_to_persistent] = intid
+
+        reference_to_persistent._p_changed = True
+
+        # Refresh provided interfaces cache
+        directlyProvides(base, directlyProvidedBy(base))
+
+        mail.reindexObject()
+        print 'Mail {}:{} fixed new class: {}'.format(mail, intid, mail.__class__)
+        print '/'.join(mail.getPhysicalPath())
+
+    transaction.commit()
+
+
+def main():
+    plone = setup_plone(setup_app())
+    fix_mail_class(plone)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
When migrating the class of contenttypes one must ensure that all the references to instances are updated/changed as well, see https://www.fourdigits.nl/blog/changing-your-packagename#1411464714874959. This PR adds two scripts to recover from incorrectly migrated mail classes and make sure that all references are up to date as well.

- fix_mail_class_intids: fixes references from the `intid` utility and should theoretically migrate all broken mails
- fix_mail_class_query: due to historical reasons, it was used first to recover from a failed migration but did not update the underlying problem, i.e. references from the intid utility. It should be run after above script to make sure that all is well.

See https://github.com/4teamwork/opengever.core/issues/1215.