### PR TITLE
Add browser view to register logging filters for the SQLAlchemy logger

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 1.0 (unreleased)
 ----------------
 
+- Add browser view to register logging filters for the SQLAlchemy logger to
+  control its verbosity.
+  [lgraf]
+
 - Add script to find uncatalogued mails.
   [deiferni]
 

--- a/opengever/maintenance/browser/enable_sqlalchemy_logging_filter.py
+++ b/opengever/maintenance/browser/enable_sqlalchemy_logging_filter.py
@@ -1,0 +1,58 @@
+from five import grok
+from opengever.ogds.base.utils import create_session
+from Products.CMFPlone.interfaces import IPloneSiteRoot
+from threading import RLock
+import logging
+
+
+# Module globals to track whether the next bound SQL parameters should be
+# logged or not, and the according lock to ensure thread safety
+_log_next_param = False
+_log_next_param_lock = RLock()
+
+
+class TaskUpdateFilter(logging.Filter):
+    """Filters records so that only UPDATE statements for the 'task' table
+    and the corresponding parameters are logged
+    """
+
+    @staticmethod
+    def filter(record):
+        global _log_next_param
+
+        if _log_next_param and TaskUpdateFilter.is_param_entry(record):
+            with _log_next_param_lock:
+                _log_next_param = False
+            return True
+
+        if 'UPDATE tasks' in record.msg:
+            with _log_next_param_lock:
+                _log_next_param = True
+            return True
+
+        return False
+
+    @staticmethod
+    def is_param_entry(record):
+        return record.args != () and record.msg == '%r'
+
+
+class EnableSQLAlchemyLoggingFilter(grok.View):
+    """Registers a filter for the sqlalchemy.engine.base.Engine logger that
+    only logs records related to task syncing.
+    """
+
+    grok.name('enable-sqlalchemy-logging-filter')
+    grok.context(IPloneSiteRoot)
+    grok.require('cmf.ManagePortal')
+
+    def render(self):
+        session = create_session()
+        engine = session.bind
+        sqlalchemy_logger = engine.logger.logger
+
+        if sqlalchemy_logger.filters != []:
+            return "Filter already enabled."
+
+        sqlalchemy_logger.addFilter(TaskUpdateFilter())
+        return "Enabled filter."


### PR DESCRIPTION
This view allows to register a filter for the SQLAlchemy logger that greatly reduces it's verbosity if SQLAlchemy logging is enabled with `echo=True`.

For now it registers a filter that only logs:
- `UPDATE tasks` statements
- The parameters immediately following that statement 

Usage:
- Enable SQLAlchemy logging on engine level, for example:

``` xml
    <db:engine name="opengever.db" echo="true"
      url="..." pool_recycle="3600"/>
    <db:session name="opengever" engine="opengever.db"/>
```
- Visit the `@@enable-sqlalchemy-logging-filter` view on the Plone Site root.

@phgross @deiferni 
