### PR TITLE
Script zum Zurücksetzen der Dossier-Referenznummern

### DIFF
--- a/opengever/maintenance/browser/refnum_selfcheck.py
+++ b/opengever/maintenance/browser/refnum_selfcheck.py
@@ -59,27 +59,7 @@ class RefnumSelfcheckView(grok.View):
 
         site = self.context
         checker = ReferenceNumberChecker(self.log, site)
-        self.log("Running reference number self-checks...")
-
-        self.log("Running 'check_if_dossier_refnums_are_complete'...")
-        result = checker.check_if_dossier_refnums_are_complete()
-        self.log("Done: %s" % result)
-
-        self.log("Running 'check_for_duplicate_refnums'...")
-        result = checker.check_for_duplicate_refnums()
-        self.log("Done: %s" % result)
-
-        self.log("Running 'check_if_index_equals_objdata'...")
-        result = checker.check_if_index_equals_objdata()
-        self.log("Done: %s" % result)
-
-        self.log("Running 'check_if_in_proper_mappings'...")
-        result = checker.check_if_in_proper_mappings()
-        self.log("Done: %s" % result)
-
-        self.log("Running 'check_if_mappings_are_persistent'...")
-        result = checker.check_if_mappings_are_persistent()
-        self.log("Done: %s" % result)
+        checker.selfcheck()
 
 
 class ReferenceNumberHelper(object):
@@ -137,6 +117,24 @@ class ReferenceNumberChecker(object):
     def log(self, msg):
         msg = "    " + msg
         return self.parent_logger(msg)
+
+    def selfcheck(self):
+        self.log("Running reference number self-checks...")
+
+        checks = ('check_if_dossier_refnums_are_complete',
+                  'check_for_duplicate_refnums',
+                  'check_if_index_equals_objdata',
+                  'check_if_in_proper_mappings',
+                  'check_if_mappings_are_persistent')
+
+        results = {}
+        for checkname in checks:
+            self.log("Running '{}'...".format(checkname))
+            result = getattr(self, checkname)()
+            self.log("Done {}: {}".format(checkname, result))
+            results[checkname] = result
+
+        return results
 
     def check_if_dossier_refnums_are_complete(self):
         check_result = 'PASSED'

--- a/opengever/maintenance/scripts/reset_dossier_refnums.py
+++ b/opengever/maintenance/scripts/reset_dossier_refnums.py
@@ -1,0 +1,261 @@
+from Acquisition import aq_inner
+from Acquisition import aq_parent
+from contextlib import contextmanager
+from csv import DictWriter
+from ftw.upgrade.progresslogger import ProgressLogger
+from opengever.base.adapters import DOSSIER_KEY
+from opengever.base.interfaces import IReferenceNumber
+from opengever.base.interfaces import IReferenceNumberPrefix
+from opengever.dossier.behaviors.dossier import IDossierMarker
+from opengever.maintenance.browser.refnum_selfcheck import ReferenceNumberChecker
+from opengever.maintenance.debughelpers import setup_app
+from opengever.maintenance.debughelpers import setup_plone
+from opengever.repository.repositoryroot import IRepositoryRoot
+from persistent.dict import PersistentDict
+from persistent.list import PersistentList
+from Products.CMFCore.utils import getToolByName
+from zope.annotation.interfaces import IAnnotations
+import logging
+import os.path
+import sys
+import transaction
+import uuid
+
+
+DOSSIER_TYPES = (
+    'opengever.dossier.businesscasedossier',
+    'opengever.dossier.templatedossier',
+    'opengever.meeting.meetingdossier',
+)
+
+REPOSTORY_TYPES = (
+    'opengever.repository.repositoryfolder',
+)
+
+
+class Abort(Exception):
+    pass
+
+
+handler = logging.StreamHandler(stream=sys.stdout)
+handler.setFormatter(logging.Formatter('[%(levelname)s] %(message)s'))
+logging.root.addHandler(handler)
+logging.root.setLevel(logging.INFO)
+
+
+STATS_CSV_APTH = os.path.abspath(
+    os.path.join(__file__,
+                 '..', '..', '..', '..',
+                 'reset_dossier_refnums_statistics.csv'))
+
+
+BACKUPS_KEY = 'reference_numbers_backups'
+LAST_BACKUP_ID_KEY = 'reference_numbers_last_backup_id'
+BACKUP_ID = str(uuid.uuid4())
+
+
+class DossierRefnumsResetter(object):
+
+    def __init__(self, portal):
+        self.portal = portal
+        self.catalog = getToolByName(self.portal, 'portal_catalog')
+
+    def __call__(self):
+        transaction.get().note('reset_dossier_refnums')
+        try:
+            with RefnumsStatistics(self.catalog)():
+                self.reset_dossier_refnums()
+                print ''
+                print ''
+                self.update_catalog()
+
+            self.selfcheck()
+
+        except Abort, exc:
+            transaction.abort()
+            print ''
+            print 'ABORTING TRANSACTION'
+            print 'Reason:', str(exc)
+
+    def reset_dossier_refnums(self):
+        msg = 'Resetting dossier reference numbers now.'
+        brains = self.catalog(object_provides=IDossierMarker.__identifier__,
+                              sort_on='created')
+        map(self.reset_dossier_by_brain, ProgressLogger(msg, brains))
+
+    def reset_dossier_by_brain(self, brain):
+        obj = brain.getObject()
+        parent = aq_parent(aq_inner(obj))
+        self.maybe_reset_storage(parent)
+        IReferenceNumberPrefix(parent).set_number(obj)
+
+    def maybe_reset_storage(self, parent):
+        """Reset the reference number storage when we didn't do it already
+        in this run.
+        """
+        annotations = IAnnotations(parent)
+        if annotations.get(LAST_BACKUP_ID_KEY, '') == BACKUP_ID:
+            # Already done.
+            return
+
+        if BACKUPS_KEY not in annotations:
+            annotations[BACKUPS_KEY] = PersistentList()
+
+        annotations[BACKUPS_KEY].append(PersistentDict({
+            DOSSIER_KEY: annotations.get(DOSSIER_KEY, None),
+            LAST_BACKUP_ID_KEY: annotations.get(LAST_BACKUP_ID_KEY, None),
+        }))
+
+        annotations[DOSSIER_KEY] = PersistentDict()
+        annotations[LAST_BACKUP_ID_KEY] = BACKUP_ID
+
+    def update_catalog(self):
+        # We may have changed all reference numbers of dossiers.
+        # In order to make sure that the catalog values are up to date,
+        # we therefore must reindex all dossiers
+        # and all documents within dossiers.
+        # Since the repository may be the smaller part of the database,
+        # we just reindex everything for simplicity.
+        # It may take a little longer, but we really want to be sure that
+        # the catalog is consistent.
+
+        msg = 'Catalog: update "reference" index and all metadata.'
+        for brain in ProgressLogger(msg, self.catalog()):
+            obj = brain.getObject()
+            obj.reindexObject(idxs=['reference'])
+
+    def selfcheck(self):
+        print ''
+        print '=' * 30
+
+        def print_logger(msg):
+            print msg
+
+        checker = ReferenceNumberChecker(print_logger, self.portal)
+        results = checker.selfcheck()
+        if set(results.values()) != {'PASSED'}:
+            raise Abort('Selfcheck failed.')
+
+
+def make_utf8(value):
+    if isinstance(value, unicode):
+        return value.encode('utf-8')
+
+    if isinstance(value, str):
+        return value
+
+    if isinstance(value, list):
+        return map(make_utf8, value)
+
+    if isinstance(value, tuple):
+        return tuple(map(make_utf8, value))
+
+    if isinstance(value, dict):
+        return dict(zip(*map(make_utf8, zip(*value.items()))))
+
+    raise TypeError('make_utf8 does not suppot {}'.format(type(value)))
+
+
+class RefnumsStatistics(object):
+
+    def __init__(self, catalog):
+        self.catalog = catalog
+
+    @contextmanager
+    def __call__(self):
+        if os.path.exists(STATS_CSV_APTH):
+            print 'Error: file exists:', STATS_CSV_APTH
+            print 'Not going to overwrite.'
+            sys.exit(1)
+
+        stats = self.statistics('before', {})
+        yield
+        stats = self.statistics('after', stats)
+        map(self.validate_stastics, stats.values())
+        self.write_statistics(stats)
+        not_ok = filter(lambda item: not item['status'].startswith('OK'),
+                        stats.values())
+        if len(not_ok):
+            raise Abort('Having {} wrong items; aborting'.format(
+                len(not_ok)))
+
+    def statistics(self, key, stats):
+        for brain in self.catalog(sort_on='path'):
+            obj = brain.getObject()
+            if self.should_be_skipped(obj):
+                continue
+
+            if brain.getPath() not in stats:
+                stats[brain.getPath()] = {
+                    'path': brain.getPath(),
+                    'portal_type': brain.portal_type,
+                    'title': brain.Title,
+                }
+
+            stats[brain.getPath()].update({
+                key + '-catalog': brain.reference,
+                key + '-obj': IReferenceNumber(obj).get_number(),
+            })
+
+        return stats
+
+    def validate_stastics(self, item):
+        keys = {'before-catalog', 'before-obj', 'after-catalog', 'after-obj'}
+        item['status'] = 'OK: -'
+
+        if keys - set(item):
+            item['status'] = 'ERROR: Missing infos'
+
+        if item['portal_type'] in DOSSIER_TYPES:
+            if item['after-catalog'] != item['after-obj']:
+                item['status'] = 'ERROR: catalog not up to date?'
+            if item['after-obj'] != item['before-obj']:
+                item['status'] = 'OK: changed'
+
+        if item['portal_type'] in REPOSTORY_TYPES:
+            unique_values = set([value for (key, value) in item.items()
+                             if key in keys])
+            if len(unique_values) > 1:
+                item['status'] = ('ERROR: unpexpected changes in repository object')
+
+    def should_be_skipped(self, obj):
+        if IRepositoryRoot.providedBy(obj):
+            return True
+
+        return False
+
+    def write_statistics(self, items):
+        fieldnames = ['portal_type',
+                      'status',
+                      'before-catalog',
+                      'before-obj',
+                      'after-catalog',
+                      'after-obj',
+                      'title',
+                      'path']
+
+        print ''
+        print ''
+        print 'INFO: Writing statistics to', STATS_CSV_APTH
+
+        with open(STATS_CSV_APTH, 'w+') as csvfile:
+            writer = DictWriter(csvfile, fieldnames=fieldnames)
+            writer.writeheader()
+            for item in items.values():
+                if len(set(item) - set(fieldnames)):
+                    raise Abort('Unexpected keys {} in {}'.format(
+                        set(item) - set(fieldnames), item))
+                writer.writerow(make_utf8(item))
+
+
+if __name__ == '__main__':
+    app = setup_app()
+    plone = setup_plone(app, [])
+
+    if True:
+        print 'WARNING: transaction dommed because we are in dry-mode.'
+        print ''
+        transaction.doom()
+
+    DossierRefnumsResetter(plone)()
+    transaction.commit()

--- a/opengever/maintenance/scripts/reset_dossier_refnums.py
+++ b/opengever/maintenance/scripts/reset_dossier_refnums.py
@@ -105,7 +105,7 @@ class DossierRefnumsResetter(object):
 
         container = annotations[REPOSITORY_FOLDER_KEY]
         for key in (CHILD_REF_KEY, PREFIX_REF_KEY):
-            if type(container[key]) != dict:
+            if type(container.get(key)) != dict:
                 continue
 
             container[key] = PersistentDict(container[key])

--- a/opengever/maintenance/scripts/reset_dossier_refnums.py
+++ b/opengever/maintenance/scripts/reset_dossier_refnums.py
@@ -43,7 +43,7 @@ logging.root.addHandler(handler)
 logging.root.setLevel(logging.INFO)
 
 
-STATS_CSV_APTH = os.path.abspath(
+STATS_CSV_PATH = os.path.abspath(
     os.path.join(__file__,
                  '..', '..', '..', '..',
                  'reset_dossier_refnums_statistics.csv'))
@@ -163,8 +163,8 @@ class RefnumsStatistics(object):
 
     @contextmanager
     def __call__(self):
-        if os.path.exists(STATS_CSV_APTH):
-            print 'Error: file exists:', STATS_CSV_APTH
+        if os.path.exists(STATS_CSV_PATH):
+            print 'Error: file exists:', STATS_CSV_PATH
             print 'Not going to overwrite.'
             sys.exit(1)
 
@@ -236,9 +236,9 @@ class RefnumsStatistics(object):
 
         print ''
         print ''
-        print 'INFO: Writing statistics to', STATS_CSV_APTH
+        print 'INFO: Writing statistics to', STATS_CSV_PATH
 
-        with open(STATS_CSV_APTH, 'w+') as csvfile:
+        with open(STATS_CSV_PATH, 'w+') as csvfile:
             writer = DictWriter(csvfile, fieldnames=fieldnames)
             writer.writeheader()
             for item in items.values():


### PR DESCRIPTION
Closes #48 

Das Script `reset_dossier_refnums.py` vergibt allen Dossiers (`IDossierMarker`) neue Referenznummern und indexiert alles neu.

Das Script wird mit `./bin/instance run src/opengever.maintenance/opengever/maintenance/scripts/reset_dossier_refnums.py`

**Implementation:**
- Das Script setzt den Dossier-Referenznummern storage auf jedem parent eines dossier (d.h. repository folders und dossiers) neu, indem ein neues `PersistentDict` zugewiesen wird.
- Anschliessend wird regulär per adapter dem Dossier die nächste freie Nummer vergeben.
- Der Katalog wird für alle Objekte aktualisiert (Metadaten + `reference`-Index).

**Integrität, Schutzmechanismen und Logging:**
- Es wird mit `transaction.doom` gestartet; die entsprechende Condition muss im Code geändert werden wenns ernst gilt :wink: 
- Nach der Korrektur wird der Selfcheck des `ReferenceNumberChecker` (`@@refnum-selfcheck`) ausgeführt. Wenn nicht alles OK ist wird die Transaktion abgebrochen.
- Vor und nach der Änderung wird eine Statistik (fast) aller Objekte gemacht und die beiden Stände verglichen. Bei unerwarteten Änderungen wird gewarnt und abgebrochen (z.B. wenn sich die Nummer einer Ordnungsposition ändert). Die Statistik wird als `reset_dossier_refnums_statistics.csv` im Buildout-Root abgelegt. Daraus kann die alte und neue Nummer jedes Dossiers ausgelesen werden.

**Backup:**
Das Zurückgesetzt `PersistentDict` wird in den Annotations gebackupt. Das Script kann mehrmals laufen gelassen werden, jeder Stand wird in einem frischen Backup speichert.

**Bemerkungen:**
- `ReferenceNumberChecker`: Ich musste den reference number checker anpassen: vorher war der selfcheck (d.h. die Liste von checks) in der View, welche eine gedoomte Transaktion hatte. Ich habe die selfcheck-Logik nun in eine Methode des `ReferenceNumberChecker` ausgelagert, so dass ich, ohne view, den selfcheck aus meinem Script ausführen konnte.
- Die Statistik enthält das Repository-Root nicht, weil dessen Referenznummer trotz extra definiertem Adapter eine Exception wirft. Da dies für mich nicht relevant ist habe ich es nicht weiter verfolgt.
- Die Liste der Dossier-Typen macht die Verifizierung schneller, sie muss aber allenfalls noch mit mir unbekannten Dossiers ergänzt werden.