### PR TITLE
Add script to make document ids canonical.

### DIFF
--- a/opengever/maintenance/scripts/use_canonical_document_ids.py
+++ b/opengever/maintenance/scripts/use_canonical_document_ids.py
@@ -1,0 +1,120 @@
+from Acquisition import aq_inner
+from Acquisition import aq_parent
+from csv import DictWriter
+from datetime import datetime
+from opengever.maintenance.debughelpers import setup_app
+from opengever.maintenance.debughelpers import setup_option_parser
+from opengever.maintenance.debughelpers import setup_plone
+from opengever.maintenance.utils import elevated_privileges
+from plone import api
+from urlparse import urljoin
+from zope.container.interfaces import INameChooser
+import logging
+import os
+import sys
+import transaction
+import urllib
+
+
+logger = logging.getLogger('opengever.maintenance')
+handler = logging.StreamHandler(stream=sys.stdout)
+logging.root.addHandler(handler)
+logging.root.setLevel(logging.INFO)
+
+SEPARATOR = '-' * 78
+
+REPORT_PATH = os.path.abspath(
+    os.path.join(__file__,
+                 '..', '..', '..', '..',
+                 'renamed_documents.csv'))
+
+
+def use_canonical_document_id(options):
+    """Rename documents that do not use the current naming-schema.
+
+    Also write a short report of the renamed documents to a csv file.
+
+    """
+    catalog = api.portal.get_tool('portal_catalog')
+    brains = catalog.unrestrictedSearchResults(
+        portal_type='opengever.document.document')
+
+    to_rename = []
+
+    for brain in brains:
+        name = brain.id
+        if name.startswith('template-') or name.startswith('document-'):
+            if options.verbose:
+                logger.info("skipped: {}".format(brain.getPath()))
+            continue
+
+        to_rename.append(brain.getObject())
+
+    if to_rename:
+        logger.info(SEPARATOR)
+
+    def build_url(fragment):
+        fragment = urllib.quote(fragment)
+        if not options.domain:
+            return fragment
+
+        # we assume a virtualhost and strip the plone site id
+        assert fragment.startswith("/"), "path should start with /"
+        visible_fragment = "/".join(fragment.split('/')[2:])
+        base = "https://{}/".format(options.domain)
+        return urljoin(base, visible_fragment)
+
+    with open(REPORT_PATH, 'w+') as csvfile:
+        writer = DictWriter(csvfile, fieldnames=["old_url", "new_url"])
+        writer.writeheader()
+
+        # elevated privileges are necessary to be able to modify stuff in
+        # closed dossiers.
+        with elevated_privileges():
+            for obj in to_rename:
+                parent = aq_parent(aq_inner(obj))
+                old_name = obj.getId()
+                old_url = '/'.join(obj.getPhysicalPath())
+                new_name = INameChooser(parent).chooseName(None, obj)
+                logger.info("renaming '{}' to '{}' ({})".format(
+                    old_name, new_name, '/'.join(obj.getPhysicalPath())))
+                api.content.rename(obj=obj, new_id=new_name)
+                new_url = '/'.join(obj.getPhysicalPath())
+                writer.writerow({
+                    "old_url": build_url(old_url),
+                    "new_url": build_url(new_url)
+                })
+
+    if not options.dry_run:
+        transaction.commit()
+
+    logger.info("done.")
+
+
+def main():
+    app = setup_app()
+
+    parser = setup_option_parser()
+    parser.add_option("-n", dest="dry_run", action="store_true", default=False)
+    parser.add_option("--domain", dest="domain", default=None,
+                      help="Domain used in links to renamed content in "
+                           "report file.")
+    (options, args) = parser.parse_args()
+
+    if options.domain:
+        assert not options.domain.startswith("http")
+        assert not options.domain.endswith("/")
+
+    logger.info(SEPARATOR)
+    logger.info("Date: {}".format(datetime.now().isoformat()))
+    setup_plone(app, options)
+
+    if options.dry_run:
+        transaction.doom()
+        logger.info("DRY-RUN")
+
+    use_canonical_document_id(options)
+
+
+if __name__ == '__main__':
+    main()

--- a/opengever/maintenance/utils.py
+++ b/opengever/maintenance/utils.py
@@ -1,3 +1,10 @@
+from AccessControl.SecurityManagement import getSecurityManager
+from AccessControl.SecurityManagement import newSecurityManager
+from AccessControl.SecurityManagement import setSecurityManager
+from AccessControl.User import UnrestrictedUser as BaseUnrestrictedUser
+from contextlib import contextmanager
+from plone import api
+from zope.globalrequest import getRequest
 
 
 def join_lines(fn):
@@ -6,3 +13,45 @@ def join_lines(fn):
     def wrapped(self, *args, **kwargs):
         return '\n'.join(fn(self, *args, **kwargs))
     return wrapped
+
+
+class UnrestrictedUser(BaseUnrestrictedUser):
+    """Unrestricted user that still has an id.
+    """
+
+    def getId(self):
+        """Return the ID of the user.
+        """
+        return self.getUserName()
+
+
+@contextmanager
+def elevated_privileges():
+    """Temporarily elevate current user's privileges.
+
+    See http://docs.plone.org/develop/plone/security/permissions.html#bypassing-permission-checks
+    for more documentation on this code.
+
+    Copy of opengever.base.security.elevated_privileges to make this
+    functionality available for older plone versions.
+    XXX can be removed eventually
+
+    """
+    old_manager = getSecurityManager()
+    try:
+        # Clone the current user and assign a new role.
+        # Note that the username (getId()) is left in exception
+        # tracebacks in the error_log,
+        # so it is an important thing to store.
+        tmp_user = UnrestrictedUser(
+            api.user.get_current().getId(), '', ('manage', ), ''
+            )
+
+        # Wrap the user in the acquisition context of the portal
+        tmp_user = tmp_user.__of__(api.portal.get().acl_users)
+        newSecurityManager(getRequest(), tmp_user)
+
+        yield
+    finally:
+        # Restore the old security manager
+        setSecurityManager(old_manager)


### PR DESCRIPTION
Dieser PR beinhaltet ein Skript `use_canonical_document_ids.py` welches Dokumente mit falscher ID zur kanonischen Form `document-[id]` konvertiert.

Zum Testen können Dokument-ids z.B. folgendermassen geändert werden:

```python
def break_document_ids(options):
    """DEV-method, use to break the document ids.

    """
    catalog = api.portal.get_tool('portal_catalog')
    brains = catalog.unrestrictedSearchResults(
        portal_type='opengever.document.document')

    for number, brain in enumerate(brains):
        old_name = brain.id
        new_name = "with spaces {}".format(number)
        obj = brain.getObject()
        api.content.rename(obj=obj, new_id=new_name)
        print "broke {} to {} ({})".format(old_name, new_name,
                                           '/'.join(obj.getPhysicalPath()))

    if not options.dry_run:
        transaction.commit()
    print "done breaking."
```