### PR TITLE
Fix-Skript für nicht eingelesene retention_period.

### DIFF
--- a/opengever/maintenance/scripts/fix_retention_period.py
+++ b/opengever/maintenance/scripts/fix_retention_period.py
@@ -136,12 +136,12 @@ class RepoFolderDiff(RepoRootDiff):
         return self._is_leaf_folder
 
     def _diff(self):
-        reference_number = self._get_repository_reference_number()
-        if reference_number != self.item['reference_number']:
+        self.reference_number = self._get_repository_reference_number()
+        if self.reference_number != self.item['reference_number']:
             logger.warn('reference numbers differ for {}: '
                         '"{}" (site), "{}" (excel)'
                         .format(self.path,
-                                reference_number,
+                                self.reference_number,
                                 self.item["reference_number"]))
             self.can_apply = False
             return
@@ -177,14 +177,18 @@ class RepoFolderDiff(RepoRootDiff):
         kind = 'leaf ' if self.is_leaf_folder else ''
         if self.current_period != DEFAULT_PERIOD:
             if self.options.verbose:
-                logger.info('skipping {}repo-folder {}, modified'
-                            .format(kind, self.item['_query_path']))
+                logger.info('skipping {}repo-folder ({}) {}, modified'
+                            .format(kind,
+                                    self.reference_number,
+                                    self.item['_query_path']))
             return False
 
         if self.current_period == self.new_period:
             if self.options.verbose:
-                logger.info('skipping {}repo-folder {}, not changed'
-                            .format(kind, self.item['_query_path']))
+                logger.info('skipping {}repo-folder ({}) {}, not changed'
+                            .format(kind,
+                                    self.reference_number,
+                                    self.item['_query_path']))
             return False
 
         current_title = self.context.Title(prefix_with_reference_number=False)
@@ -192,17 +196,24 @@ class RepoFolderDiff(RepoRootDiff):
         xls_title = self.item['effective_title']
         if current_title != xls_title:
             if self.options.verbose:
-                logger.info(u'skipping {}repo-folder {}, title changed '
+                logger.info(u'skipping {}repo-folder ({}) {}, title changed '
                             u'from "{}" to "{}"'
-                            .format(kind, self.item['_query_path'],
-                                    xls_title, current_title))
+                            .format(kind,
+                                    self.reference_number,
+                                    self.item['_query_path'],
+                                    xls_title,
+                                    current_title))
             return False
 
         if self.options.verbose:
-            logger.info('fixing {}repo-folder {}, {}->{}'
-                        .format(kind, self.item['_query_path'],
-                                self.current_period, self.new_period))
+            logger.info('fixing {}repo-folder ({}) {}, {}->{}'
+                        .format(kind,
+                                self.reference_number,
+                                self.item['_query_path'],
+                                self.current_period,
+                                self.new_period))
         ILifeCycle(self.context).retention_period = self.new_period
+        return True
 
     def apply_to_dossier(self, dossier):
         dossier_path = '/'.join(dossier.getPhysicalPath())

--- a/opengever/maintenance/scripts/fix_retention_period.py
+++ b/opengever/maintenance/scripts/fix_retention_period.py
@@ -80,6 +80,19 @@ class FixerPathFromReferenceNumber(PathFromReferenceNumberSection):
         self.id_normalizer = queryUtility(IIDNormalizer)
         self.reference_formatter = reference_formatter
 
+    def has_grouped_by_three_reference_number_formatter(self):
+        if isinstance(self.reference_formatter, basestring):
+            return self.reference_formatter in [
+                'grouped_by_three', 'no_client_id_grouped_by_three']
+
+        return self.reference_formatter.is_grouped_by_three
+
+    def get_reference_number(self, refnum):
+        if self.has_grouped_by_three_reference_number_formatter():
+            cl_refnum = refnum.replace('.', '')
+            return '.'.join(cl_refnum)
+        return refnum
+
 
 class RepoRootDiff(object):
 

--- a/opengever/maintenance/scripts/fix_retention_period.py
+++ b/opengever/maintenance/scripts/fix_retention_period.py
@@ -1,0 +1,71 @@
+from opengever.maintenance.debughelpers import setup_app
+from opengever.maintenance.debughelpers import setup_option_parser
+from opengever.maintenance.debughelpers import setup_plone
+from plone import api
+import os
+import os.path
+import transaction
+
+
+REPOSITORIES_FOLDER_NAME = 'opengever_repositories'
+
+
+class Abort(Exception):
+    pass
+
+
+class RetentionPeriodFixer(object):
+
+    def __init__(self, plone, profile):
+        self.plone = plone
+        self.profile = profile
+        self.portal_setup = api.portal.get_tool('portal_setup')
+
+    def run(self):
+        repository_file_path = self.get_repository_file_path()
+
+    def get_repository_file_path(self):
+        profile_info = self.portal_setup.getProfileInfo(self.profile)
+        profile_path = profile_info['path']
+
+        repositories_folder = os.path.join(profile_path,
+                                           REPOSITORIES_FOLDER_NAME)
+        repository_filenames = [filename for filename in
+                                os.listdir(repositories_folder)
+                                if filename.endswith('.xlsx')]
+
+        if len(repository_filenames) != 1:
+            raise Abort("Expected one repository file but found {}, {}".format(
+                        len(repository_filenames), repository_filenames))
+
+        return os.path.join(repositories_folder, repository_filenames[0])
+
+
+def main():
+    app = setup_app()
+    parser = setup_option_parser()
+    parser.add_option("-n", dest="dry_run", action="store_true", default=False)
+    parser.add_option("-p", dest="profile",
+                      help="profile that contains the repository excel file.")
+    options, args = parser.parse_args()
+
+    if not options.profile:
+        print "the profile (-p) argument is required."
+        return
+    if ":" not in options.profile:
+        print "invalid profile id: '{}', missing ':'".format(options.profile)
+        return
+
+    plone = setup_plone(app, options)
+    RetentionPeriodFixer(plone, options.profile).run()
+
+    if options.dry_run:
+        print 'transaction doomed because we are in dry-mode.'
+        print ''
+        transaction.doom()
+
+    transaction.commit()
+
+
+if __name__ == '__main__':
+    main()

--- a/opengever/maintenance/scripts/fix_retention_period.py
+++ b/opengever/maintenance/scripts/fix_retention_period.py
@@ -187,6 +187,17 @@ class RepoFolderDiff(RepoRootDiff):
                             .format(kind, self.item['_query_path']))
             return
 
+        current_title = self.context.Title(prefix_with_reference_number=False)
+        current_title = current_title.decode('utf-8')  # Title returns utf-8
+        xls_title = self.item['effective_title']
+        if current_title != xls_title:
+            if self.options.verbose:
+                logger.info(u'skipping {}repo-folder {}, title changed '
+                            u'from "{}" to "{}"'
+                            .format(kind, self.item['_query_path'],
+                                    xls_title, current_title))
+            return
+
         if self.options.verbose:
             logger.info('fixing {}repo-folder {}, {}->{}'
                         .format(kind, self.item['_query_path'],

--- a/opengever/maintenance/scripts/fix_retention_period.py
+++ b/opengever/maintenance/scripts/fix_retention_period.py
@@ -6,6 +6,7 @@ from opengever.base.interfaces import IReferenceNumberFormatter
 from opengever.base.interfaces import IReferenceNumberSettings
 from opengever.base.interfaces import IRetentionPeriodRegister
 from opengever.dossier.behaviors.dossier import IDossierMarker
+from opengever.journal.handlers import journal_entry_factory
 from opengever.maintenance.debughelpers import setup_app
 from opengever.maintenance.debughelpers import setup_option_parser
 from opengever.maintenance.debughelpers import setup_plone
@@ -212,6 +213,14 @@ class RepoFolderDiff(RepoRootDiff):
                         .format('/'.join(dossier.getPhysicalPath())))
 
         ILifeCycle(dossier).retention_period = self.new_period
+
+        # the log entry is untranslated on purpose, we don't want to add
+        # translations for this fix to opengever.core.
+        comment = u'Alter Wert: "{} Jahre", neuer Wert: "{} Jahre"'.format(
+            current_period, self.new_period)
+        journal_entry_factory(dossier, 'Aufbewahrungsdauer korrigiert',
+                              title=u'Aufbewahrungsdauer korrigiert.',
+                              comment=comment)
 
 
 class RetentionPeriodFixer(XlsSource):

--- a/opengever/maintenance/scripts/fix_retention_period.py
+++ b/opengever/maintenance/scripts/fix_retention_period.py
@@ -292,9 +292,9 @@ class RetentionPeriodFixer(XlsSource):
     We attempt to fix this by comparing the current repository to the initial
     excel file and setting the retention_period on the repository as follows:
 
-                    plone: no change, plone: (re-)moved, plone: changed
-    xls: no value   parent/default,   skip,              skip
-    xls: value      from xls,         skip,              skip
+                    plone: default value, plone: (re-)moved, plone: changed
+    xls: no value   parent/default,       skip,              skip
+    xls: value      from xls,             skip,              skip
 
     Values specified in the excel file are inherited by children. If an excel
     file contanis a value for a parent folder but none for a child folder the
@@ -304,10 +304,12 @@ class RetentionPeriodFixer(XlsSource):
     folder that have the same retention_period as the folder are updated
     as well, under the assumption that the value was inherited.
 
-    Note: this will set a wrong retention_period when:
-      - the repo_folders retention_period changes to non-default
-      - the child (dossier/repo-folder) should have a rentention_period equal
-        to the default retention_period.
+    Note: this will set a wrong retention_period when the following two
+    conditions are met:
+      - the parent repo_folders retention_period changes to non-default, and ...
+      - ... the child (dossier/repo-folder) should have a rentention_period
+        equal to the value of what was previously a default, but was a
+        deliberately chosen value for that dossier/repo-folder.
 
     Unfortunately this cannot be avoided since we cannot tell the difference
     between inherited and configured value.

--- a/opengever/maintenance/scripts/fix_retention_period.py
+++ b/opengever/maintenance/scripts/fix_retention_period.py
@@ -187,10 +187,6 @@ class RepoFolderDiff(RepoRootDiff):
                             .format(kind, self.item['_query_path']))
             return
 
-            if self.options.verbose:
-                logger.info('skipping {}repo-folder {}, modified'
-                            .format(kind, self.item['_query_path']))
-
         if self.options.verbose:
             logger.info('fixing {}repo-folder {}, {}->{}'
                         .format(kind, self.item['_query_path'],

--- a/opengever/maintenance/scripts/fix_retention_period.py
+++ b/opengever/maintenance/scripts/fix_retention_period.py
@@ -1,22 +1,30 @@
+from opengever.base.interfaces import IReferenceNumber
+from opengever.base.interfaces import IReferenceNumberFormatter
 from opengever.base.interfaces import IReferenceNumberSettings
 from opengever.maintenance.debughelpers import setup_app
 from opengever.maintenance.debughelpers import setup_option_parser
 from opengever.maintenance.debughelpers import setup_plone
+from opengever.repository.interfaces import IRepositoryFolder
 from opengever.setup.sections.reference import PathFromReferenceNumberSection
 from opengever.setup.sections.xlssource import XlsSource
 from plone import api
 from plone.i18n.normalizer.interfaces import IIDNormalizer
 from plone.i18n.normalizer.interfaces import IURLNormalizer
 from plone.registry.interfaces import IRegistry
+from zope.component import getAdapter
 from zope.component import getUtility
 from zope.component import queryUtility
 import logging
 import os
 import os.path
+import sys
 import transaction
 
 
 logger = logging.getLogger('opengever.maintenance')
+handler = logging.StreamHandler(stream=sys.stdout)
+logging.root.addHandler(handler)
+logging.root.setLevel(logging.INFO)
 
 REPOSITORIES_FOLDER_NAME = 'opengever_repositories'
 
@@ -49,29 +57,82 @@ class FixerPathFromReferenceNumber(PathFromReferenceNumberSection):
     No longer do transmogrifier related stuff but just generate the reference
     numbers.
     """
-    def __init__(self, previous):
+    def __init__(self, previous, reference_formatter):
         self.logger = logger
         self.previous = previous
 
         self.refnum_mapping = {}
         self.normalizer = queryUtility(IURLNormalizer, name="de")
         self.id_normalizer = queryUtility(IIDNormalizer)
+        self.reference_formatter = reference_formatter
+
+
+class RetentionPeriodFixer(XlsSource):
+
+    def __init__(self, plone, options):
+        self.plone = plone
+        self.options = options
+        self.profile = options.profile
+        self.portal_setup = api.portal.get_tool('portal_setup')
+        self.catalog = api.portal.get_tool('portal_catalog')
 
         registry = getUtility(IRegistry)
         proxy = registry.forInterface(IReferenceNumberSettings)
         self.reference_formatter = proxy.formatter
 
-
-class RetentionPeriodFixer(XlsSource):
-
-    def __init__(self, plone, profile):
-        self.plone = plone
-        self.profile = profile
-        self.portal_setup = api.portal.get_tool('portal_setup')
+    def get_repository_reference_number(self, context):
+        reference = IReferenceNumber(context)
+        formatter = getAdapter(context, IReferenceNumberFormatter,
+                               name=self.reference_formatter)
+        return formatter.repository_number(reference.get_parent_numbers())
 
     def run(self):
-        source = FixerPathFromReferenceNumber(
-            FixerXlsSource(self.get_repository_file_path()))
+        xlssource = FixerXlsSource(self.get_repository_file_path())
+        source = FixerPathFromReferenceNumber(xlssource,
+                                              self.reference_formatter)
+
+        for item in source:
+            self.fix_retention_period(item)
+
+    def fix_retention_period(self, item):
+        path = item['_path'].lstrip('/').encode('utf-8')
+        item['_query_path'] = path
+
+        context = self.plone.unrestrictedTraverse(path, default=None)
+        if not context:
+            logger.warn('could not find repository folder: {}'.format(path))
+            return
+
+        reference_number = self.get_repository_reference_number(context)
+        if reference_number != item['reference_number']:
+            logger.warn('reference numbers differ for {}: '
+                        '"{}" (site), "{}" (excel)'
+                        .format(path,
+                                reference_number,
+                                item["reference_number"]))
+            return
+
+        if self.is_leaf_folder(context):
+            self.fix_leaf_folder(context, item)
+        else:
+            self.fix_non_leaf_folder(context, item)
+
+    def is_leaf_folder(self, context):
+        child_folders = self.catalog.unrestrictedSearchResults(
+            path={'query': '/'.join(context.getPhysicalPath()),
+                  'depth': 1},
+            object_provides=IRepositoryFolder.__identifier__)
+        return len(child_folders) == 0
+
+    def fix_non_leaf_folder(self, context, item):
+        if self.options.verbose:
+            logger.info('fixing non-leaf folder {}'
+                        .format(item['_query_path']))
+
+    def fix_leaf_folder(self, context, item):
+        if self.options.verbose:
+            logger.info('fixing leaf folder {}'
+                        .format(item['_query_path']))
 
     def get_repository_file_path(self):
         profile_info = self.portal_setup.getProfileInfo(self.profile)
@@ -99,18 +160,18 @@ def main():
     options, args = parser.parse_args()
 
     if not options.profile:
-        print "the profile (-p) argument is required."
+        logger.error("the profile (-p) argument is required.")
         return
     if ":" not in options.profile:
-        print "invalid profile id: '{}', missing ':'".format(options.profile)
+        logger.error("invalid profile id: '{}', missing ':'"
+                     .format(options.profile))
         return
 
     plone = setup_plone(app, options)
-    RetentionPeriodFixer(plone, options.profile).run()
+    RetentionPeriodFixer(plone, options).run()
 
     if options.dry_run:
-        print 'transaction doomed because we are in dry-mode.'
-        print ''
+        logger.warn('transaction doomed because we are in dry-mode.')
         transaction.doom()
 
     transaction.commit()

--- a/opengever/maintenance/scripts/fix_retention_period.py
+++ b/opengever/maintenance/scripts/fix_retention_period.py
@@ -159,8 +159,7 @@ class RepoFolderDiff(RepoRootDiff):
         if not self.can_apply:
             return
 
-        self.apply_to_repo_folder()
-        if self.is_leaf_folder:
+        if self.apply_to_repo_folder() and self.is_leaf_folder:
             self.apply_to_dossiers()
 
         super(RepoFolderDiff, self).apply_recursively()
@@ -179,13 +178,13 @@ class RepoFolderDiff(RepoRootDiff):
             if self.options.verbose:
                 logger.info('skipping {}repo-folder {}, modified'
                             .format(kind, self.item['_query_path']))
-            return
+            return False
 
         if self.current_period == self.new_period:
             if self.options.verbose:
                 logger.info('skipping {}repo-folder {}, not changed'
                             .format(kind, self.item['_query_path']))
-            return
+            return False
 
         current_title = self.context.Title(prefix_with_reference_number=False)
         current_title = current_title.decode('utf-8')  # Title returns utf-8
@@ -196,7 +195,7 @@ class RepoFolderDiff(RepoRootDiff):
                             u'from "{}" to "{}"'
                             .format(kind, self.item['_query_path'],
                                     xls_title, current_title))
-            return
+            return False
 
         if self.options.verbose:
             logger.info('fixing {}repo-folder {}, {}->{}'

--- a/opengever/maintenance/scripts/fix_retention_period.py
+++ b/opengever/maintenance/scripts/fix_retention_period.py
@@ -293,9 +293,17 @@ class RetentionPeriodFixer(XlsSource):
 
         repositories_folder = os.path.join(profile_path,
                                            REPOSITORIES_FOLDER_NAME)
+
+        def is_parsable(filename):
+            if filename.startswith('.') or filename.startswith('~'):
+                return False
+            if not filename.endswith('.xlsx'):
+                return False
+            return True
+
         repository_filenames = [filename for filename in
                                 os.listdir(repositories_folder)
-                                if filename.endswith('.xlsx')]
+                                if is_parsable(filename)]
 
         if len(repository_filenames) != 1:
             raise Abort("Expected one repository file but found {}, {}".format(

--- a/opengever/maintenance/scripts/fix_retention_period.py
+++ b/opengever/maintenance/scripts/fix_retention_period.py
@@ -141,9 +141,9 @@ class RepoFolderDiff(RepoRootDiff):
     def _diff(self):
         self.reference_number = self._get_repository_reference_number()
         if self.reference_number != self.item['reference_number']:
-            logger.warn('reference numbers differ for {}: '
-                        '"{}" (site), "{}" (excel)'
-                        .format(self.path,
+            logger.warn('reference numbers differ for: {}'
+                        ' "{}" (site), "{}" (excel)'
+                        .format(self.item['_query_path'],
                                 self.reference_number,
                                 self.item["reference_number"]))
             self.can_apply = False

--- a/opengever/maintenance/scripts/fix_retention_period.py
+++ b/opengever/maintenance/scripts/fix_retention_period.py
@@ -4,6 +4,7 @@ from opengever.base.behaviors.lifecycle import ILifeCycle
 from opengever.base.interfaces import IReferenceNumber
 from opengever.base.interfaces import IReferenceNumberFormatter
 from opengever.base.interfaces import IReferenceNumberSettings
+from opengever.base.interfaces import IRetentionPeriodRegister
 from opengever.dossier.behaviors.dossier import IDossierMarker
 from opengever.maintenance.debughelpers import setup_app
 from opengever.maintenance.debughelpers import setup_option_parser
@@ -31,6 +32,10 @@ logging.root.addHandler(handler)
 logging.root.setLevel(logging.INFO)
 
 REPOSITORIES_FOLDER_NAME = 'opengever_repositories'
+
+# all affected customers use the default rentetion periods of
+# ['5', '10', '15', '20', '25']. furthermore the default of 5 is hardcoded as
+# a default value of ILifeCycle.retention_period
 DEFAULT_PERIOD = 5
 
 
@@ -245,6 +250,12 @@ class RetentionPeriodFixer(XlsSource):
         registry = getUtility(IRegistry)
         proxy = registry.forInterface(IReferenceNumberSettings)
         self.reference_formatter = proxy.formatter
+
+        retention_period_register = registry.forInterface(
+            IRetentionPeriodRegister)
+        if retention_period_register.is_restricted:
+            raise Abort("The retention periods are restricted. I'm not sure "
+                        "what that means so i don't handle it.")
 
     def run(self):
         xlssource = FixerXlsSource(self.get_repository_file_path())

--- a/opengever/maintenance/scripts/fix_retention_period.py
+++ b/opengever/maintenance/scripts/fix_retention_period.py
@@ -205,12 +205,24 @@ class RepoFolderDiff(RepoRootDiff):
         ILifeCycle(self.context).retention_period = self.new_period
 
     def apply_to_dossier(self, dossier):
-        if ILifeCycle(dossier).retention_period == self.new_period:
+        dossier_path = '/'.join(dossier.getPhysicalPath())
+        current_period = ILifeCycle(dossier).retention_period
+
+        if current_period != self.current_period:
+            if self.options.verbose:
+                logger.info('skipping dossier {}, modified'
+                            .format(dossier_path))
+            return
+
+        if current_period == self.new_period:
+            if self.options.verbose:
+                logger.info('skipping dossier {}, not changed'
+                            .format(dossier_path))
             return
 
         if self.options.verbose:
-            logger.info('fixing {} dossier {}'
-                        .format('/'.join(dossier.getPhysicalPath())))
+            logger.info('fixing dossier {}, {}->{}'
+                        .format(dossier_path, current_period, self.new_period))
 
         ILifeCycle(dossier).retention_period = self.new_period
 


### PR DESCRIPTION
Skript zum nachträglichen setzen der Aufbewahrungsdauer von Ordnungspositionen und Dossiers, falls diese nicht korrekt aus dem initialen Excel eingelesen wurden.

**Ausführen:**

Das Skript wird mit `bin/instance run` ausgeführt. Es stehen folgende Paramter zur Verfügung:

- `-p [profile_name]`, z.B. `-p 'opengever.examplecontent:repository_minimal'`, generic setup profil, welches das Excel file beinhaltet
- `-v` verbose mode
- `-n` dry-run

**Implementation:**

Die Ordnungspositionen werden nur korrigiert, falls sie noch identisch zum Excel sind. Das bedeutete, dass sowohl die Referenznummer wie auch der Titel mit dem Excel übereinstimmen müssen. Zudem muss die Aufbewahrungsdauer den Defaultwert von `5` haben (_dies stimmt bei den betroffenen Kunden gerade so, könnte theoretisch aber auch abweichen_). 

Dossiers einer Ordnungsposition werden nur korrigiert falls die Ordnungsposition korrigiert wurde und falls ihre Aufbewahrungsdauer den Defaultwert von `5` hat. Zudem werden Änderungen werden auf Dossierstufe journalisiert.

**Backup:**

Die alte Aufbewahrungsdauer wird in den Annotationen unter `retention_period_backup` gespeichert und kann so bei Bedarf wiederhergestellt werden.

_Ich habe relativ viele commits in der History und diese vorerst nicht gesquashed weil sie die Entwicklungsschritte des Skriptes etwas dokumentieren. Zum Review empfehle ich aber den gesamten diff._

Closes #57.