### PR TITLE
Add tests for opengever release 3.7.x.

### DIFF
--- a/test-og-3.7.x.cfg
+++ b/test-og-3.7.x.cfg
@@ -1,0 +1,5 @@
+[buildout]
+extends =
+    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
+    http://kgs.4teamwork.ch/release/opengever/3.7.0
+    base-testing.cfg


### PR DESCRIPTION
A new minor release requires tests for its version.