### PR TITLE
Make @@health-check view also available on Zope App Root.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.0 (unreleased)
 ----------------
 
+- Make @@health-check view also available on Zope App Root.
+  [lgraf]
+
 - Add scripts to dump catalog stats grouped by month.
   [lgraf]
 

--- a/opengever/maintenance/browser/health_check.py
+++ b/opengever/maintenance/browser/health_check.py
@@ -1,5 +1,5 @@
 from five import grok
-from Products.CMFPlone.interfaces import IPloneSiteRoot
+from zope.interface import Interface
 import json
 
 try:
@@ -15,11 +15,11 @@ class HealthCheckView(grok.View):
 
     WARNING: Keep this cheap, because
     1) it will be called regularly
-    2) it's protected with zope.Public -> accessible for Anonymous users
+    2) it's protected with zope2.Public -> accessible for Anonymous users
     """
 
     grok.name('health-check')
-    grok.context(IPloneSiteRoot)
+    grok.context(Interface)
     grok.require('zope2.Public')
 
     def render(self):


### PR DESCRIPTION
This will make the `@@health-check` view also available on the **Zope Application Root**

(*by registering it for `Interface` - `grok.context()` can't be used multiple times for the same view or take more than one interface* 😦 )

This will allow us to configure our `HttpOk` plugins to point to a health check view that

- is on the **Zope Instance** (`HttpOk` are per-instance, not per-site)
- is accessible for **Anonymous** users (otherwise the `HttpOk` plugin will always just see the login form)
- uses the **`SQLAlchemy` connection** (in order to detect `MySQL server has gone away` or similar issues)

@phgross 