### PR TITLE
Make pdb breakpoint view, accessible on every context.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.0 (unreleased)
 ----------------
 
+- Make pdb breakpoint view, accessible on every context.
+  [phgross]
+
 - Move bumblebee installation script from og.core to og.maintenace.
   [phgross]
 

--- a/opengever/maintenance/browser/pdb_breakpoint.py
+++ b/opengever/maintenance/browser/pdb_breakpoint.py
@@ -1,5 +1,5 @@
 from five import grok
-from Products.CMFPlone.interfaces import IPloneSiteRoot
+from zope.interface import Interface
 
 
 class PdbBreakpointView(grok.View):
@@ -7,7 +7,7 @@ class PdbBreakpointView(grok.View):
     """
 
     grok.name('pdb-breakpoint')
-    grok.context(IPloneSiteRoot)
+    grok.context(Interface)
     grok.require('cmf.ManagePortal')
 
 


### PR DESCRIPTION
Sometimes its easier to call the `pdb-breakpoint` view directly on a specific content.

@deiferni 