### PR TITLE
Add tests for new release 3.11.0.

### DIFF
--- a/test-og-3.11.x.cfg
+++ b/test-og-3.11.x.cfg
@@ -1,0 +1,5 @@
+[buildout]
+extends =
+    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
+    http://kgs.4teamwork.ch/release/opengever/3.11.0
+    base-testing.cfg


### PR DESCRIPTION
This PR adds a test configuration file to test `opengever.maintenance` against the recently created release 3.11.0.