### PR TITLE
Bump 3.11.x tests configuration to latest release; 3.11.1.

### DIFF
--- a/test-og-3.11.x.cfg
+++ b/test-og-3.11.x.cfg
@@ -1,5 +1,5 @@
 [buildout]
 extends =
     https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
-    http://kgs.4teamwork.ch/release/opengever/3.11.0
+    http://kgs.4teamwork.ch/release/opengever/3.11.1
     base-testing.cfg


### PR DESCRIPTION
Use 3.11.1 release in 3.11.x release compatibility tests.