### PR TITLE
update og-maintenance test configuration

### DIFF
--- a/test-og-2017.1.x.cfg
+++ b/test-og-2017.1.x.cfg
@@ -1,0 +1,5 @@
+[buildout]
+extends =
+    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
+    http://kgs.4teamwork.ch/release/opengever/2017.1.0
+    base-testing.cfg

--- a/test-og-3.0.x.cfg
+++ b/test-og-3.0.x.cfg
@@ -1,5 +1,0 @@
-[buildout]
-extends =
-    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.2.x.cfg
-    http://kgs.4teamwork.ch/release/opengever/3.0.5
-    base-testing.cfg

--- a/test-og-3.2.x.cfg
+++ b/test-og-3.2.x.cfg
@@ -1,5 +1,0 @@
-[buildout]
-extends =
-    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.2.x.cfg
-    http://kgs.4teamwork.ch/release/opengever/3.2
-    base-testing.cfg

--- a/test-og-3.3.x.cfg
+++ b/test-og-3.3.x.cfg
@@ -1,5 +1,0 @@
-[buildout]
-extends =
-    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.2.x.cfg
-    http://kgs.4teamwork.ch/release/opengever/3.3.3
-    base-testing.cfg


### PR DESCRIPTION
- add tests for 2017.1.0 release
- drop tests for now unused versions