### PR TITLE
Canonicalize the dev version in order to squelch a setuptools warning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 import os
 
-version = '1.0dev'
+version = '1.0dev0'
 
 tests_require = [
     'ftw.testing',


### PR DESCRIPTION
Ref. [PEP-440](https://www.python.org/dev/peps/pep-0440/#implicit-development-release-number).