### PR TITLE
Remove includeDependencies directive.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 1.0 (unreleased)
 ----------------
 
+- Remove includeDependencies directive. [jone]
+
 - Update MySQL2PostgreSQL script: Add new sequence definitions.
   [lgraf]
 

--- a/opengever/maintenance/configure.zcml
+++ b/opengever/maintenance/configure.zcml
@@ -1,11 +1,11 @@
-<configure xmlns="http://namespaces.zope.org/zope"
-           xmlns:grok="http://namespaces.zope.org/grok"
-           xmlns:i18n="http://namespaces.zope.org/i18n"
-           i18n_domain="opengever.maintenance">
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:grok="http://namespaces.zope.org/grok"
+    xmlns:i18n="http://namespaces.zope.org/i18n"
+    i18n_domain="opengever.maintenance">
 
-    <include package="z3c.autoinclude" file="meta.zcml" />
-    <includeDependencies package="." />
+  <include package="five.grok" />
 
-    <grok:grok package="." />
+  <grok:grok package="." />
 
 </configure>


### PR DESCRIPTION
The includeDependencies directive is used for including the ZCML of dependencies, which do not provide a z3c.autoinclude entry point. Nowadays most packages provide the entry point.

The includeDependencies directive is including all dependencies. This is not explicit and it may load a lot of ZCML.

This removes the includeDependencies directive and loads five.grok explicitly.