### PR TITLE
Extend from opengever.core master versions.

### DIFF
--- a/test-og-develop.cfg
+++ b/test-og-develop.cfg
@@ -3,7 +3,7 @@
 extends =
     https://raw.githubusercontent.com/4teamwork/opengever.core/master/sources.cfg
     https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
-    http://kgs.4teamwork.ch/release/opengever/develop
+    https://raw.githubusercontent.com/4teamwork/opengever.core/master/versions.cfg
     base-testing.cfg
 
 auto-checkout -=


### PR DESCRIPTION
Instead of deprecated develop kgs instead versions from https://raw.githubusercontent.com/4teamwork/opengever.core/master/versions.cfg. The develop kgs is deprecated and no longer maintained, thus versions mismatched.

This fixes the currently broken tests against master since now the versions pinnings are correct.