### PR TITLE
Drop no longer installed releases from being tested.

### DIFF
--- a/test-og-2017.1.x.cfg
+++ b/test-og-2017.1.x.cfg
@@ -1,5 +1,0 @@
-[buildout]
-extends =
-    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
-    http://kgs.4teamwork.ch/release/opengever/2017.1.1
-    base-testing.cfg

--- a/test-og-2017.3.x.cfg
+++ b/test-og-2017.3.x.cfg
@@ -1,5 +1,0 @@
-[buildout]
-extends =
-    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
-    https://raw.githubusercontent.com/4teamwork/opengever.core/2017.3.2/versions.cfg
-    base-testing.cfg

--- a/test-og-3.5.x.cfg
+++ b/test-og-3.5.x.cfg
@@ -1,5 +1,0 @@
-[buildout]
-extends =
-    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
-    http://kgs.4teamwork.ch/release/opengever/3.5.2
-    base-testing.cfg

--- a/test-og-3.6.x.cfg
+++ b/test-og-3.6.x.cfg
@@ -1,5 +1,0 @@
-[buildout]
-extends =
-    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
-    http://kgs.4teamwork.ch/release/opengever/3.6.0
-    base-testing.cfg

--- a/test-og-3.8.x.cfg
+++ b/test-og-3.8.x.cfg
@@ -1,5 +1,0 @@
-[buildout]
-extends =
-    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
-    http://kgs.4teamwork.ch/release/opengever/3.8.3
-    base-testing.cfg

--- a/test-og-3.9.x.cfg
+++ b/test-og-3.9.x.cfg
@@ -1,5 +1,0 @@
-[buildout]
-extends =
-    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
-    http://kgs.4teamwork.ch/release/opengever/3.9.2
-    base-testing.cfg


### PR DESCRIPTION
According to `matrix` the following versions of opengever.core/kgs respectively are still installed somewhere:

3.4.1 (og.core: 4.5.1)
3.4.8 (og.core: 4.5.8)
3.7.1 (og.core: 4.8.1)
3.10.3 (og.core: 4.14.1)
3.11.1 (og.core: 4.15.1)
3.11.6 (og.core: 4.15.6)
3.11.7 (og.core: 4.15.7)

2017.2.3
2017.2.4
2017.2.5
2017.4.0
2017.5.0
2017.5.1
2017.6.0
2017.6.1

With this PR i propose to no longer test against the not installed releases as i don't see why we would install them.