### PR TITLE
Test against most recent 2017.6.x release.

### DIFF
--- a/test-og-2017.6.x.cfg
+++ b/test-og-2017.6.x.cfg
@@ -1,5 +1,5 @@
 [buildout]
 extends =
     https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
-    https://raw.githubusercontent.com/4teamwork/opengever.core/2017.6.2/versions.cfg
+    https://raw.githubusercontent.com/4teamwork/opengever.core/2017.6.3/versions.cfg
     base-testing.cfg


### PR DESCRIPTION
`pass`