### PR TITLE
 Warmup view: Add mode to warm up entire catalog

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 1.0 (unreleased)
 ----------------
 
+- Warmup view: Add mode to warm up entire catalog. [lgraf]
+
 - Add script to fix mail message caches. [lgraf]
 
 - Add script to list .url files. [lgraf]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.0 (unreleased)
 ----------------
 
+- Warmup view: Run with elevated privileges in order to be able to fetch
+  objects, and use unrestrictedSearchResults(). [lgraf]
+
 - Warmup view: Drop 'full' mode - it's prohibitively expensive and rather
   pointless anyway. [lgraf]
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.0 (unreleased)
 ----------------
 
+- Warmup view: Drop 'full' mode - it's prohibitively expensive and rather
+  pointless anyway. [lgraf]
+
 - Warmup view: Add mode to warm up entire catalog. [lgraf]
 
 - Add script to fix mail message caches. [lgraf]

--- a/opengever/maintenance/browser/warmup.py
+++ b/opengever/maintenance/browser/warmup.py
@@ -1,4 +1,5 @@
 from Acquisition import aq_base
+from functools import wraps
 from opengever.contact.contact import IContact
 from opengever.document.behaviors import IBaseDocument
 from opengever.dossier.behaviors.dossier import IDossierMarker
@@ -17,6 +18,7 @@ from Products.PluginIndexes.BooleanIndex.BooleanIndex import BooleanIndex
 from Products.PluginIndexes.DateIndex.DateIndex import DateIndex
 from Products.PluginIndexes.DateRangeIndex.DateRangeIndex import DateRangeIndex
 from Products.PluginIndexes.FieldIndex.FieldIndex import FieldIndex
+from Products.PluginIndexes.interfaces import IPluggableIndex
 from Products.PluginIndexes.KeywordIndex.KeywordIndex import KeywordIndex
 from Products.PluginIndexes.UUIDIndex.UUIDIndex import UUIDIndex
 from Products.ZCTextIndex.ZCTextIndex import ZCTextIndex
@@ -37,6 +39,148 @@ COMMON_TYPES = [
     ITask,
     ITaskTemplate,
 ]
+
+
+class CacheStats(object):
+
+    def __init__(self, conn):
+        self.conn = conn
+        self.db = conn.db()
+        self.stats_by_idx = {}
+
+    def get_rss(self):
+        """Returns this process' current RSS (in kb).
+        """
+        return get_rss()
+
+    def get_cache_size(self):
+        """Returns the PickleCache's current size (in # of objects).
+        """
+        return self.conn.db().cacheSize()
+
+    def get_estimated_size(self):
+        """Returns the current estimated size of the PickleCache in bytes.
+        """
+        return self.conn._cache.total_estimated_size
+
+    @staticmethod
+    def track(func):
+        """Decorator that tracks change in time, RSS, cache size in # objs
+        and estimated cache size in bytes.
+        """
+        @wraps(func)
+        def wrapper(self, *args, **kwargs):
+            view = self
+            cache_stats = view.cache_stats
+
+            # Choose a tag (label for the thing being tracked) based on which
+            # method is being decorated.
+            #
+            # For the warmup_index / warmup_lexicon methods this will be the
+            # index's name, for the stats regarding the entire catalog or the
+            # warmup of metadata we'll just use a static label of 'total'
+            # (since there is no granular tracking data available).
+            if func.__name__ in ('warmup_catalog', 'warmup_metadata'):
+                tag = 'total'
+            else:
+                index = args[0]
+
+                if not IPluggableIndex.providedBy(index):
+                    raise TypeError("%r is not an index" % index)
+
+                tag = index.__name__
+
+            category = func.__name__
+
+            before = {
+                'time': time.time(),
+                'rss': cache_stats.get_rss(),
+                'objs': cache_stats.get_cache_size(),
+            }
+
+            try:
+                return func(self, *args, **kwargs)
+            finally:
+
+                after = {
+                    'time': time.time(),
+                    'rss': cache_stats.get_rss(),
+                    'objs': cache_stats.get_cache_size(),
+                }
+
+                stats_by_idx = view.cache_stats.stats_by_idx
+                if category not in stats_by_idx:
+                    stats_by_idx[category] = {}
+
+                stats = {
+                    'duration': after['time'] - before['time'],
+                    'rss_delta': after['rss'] - before['rss'],
+                    'obj_delta': after['objs'] - before['objs'],
+                }
+
+                stats_by_idx[category][tag] = stats
+
+        return wrapper
+
+    def format_rss_delta(self, rss_delta):
+        return 'RSS (delta): %7.2f MiB' % (rss_delta / 1024.0)
+
+    def format_obj_delta(self, obj_delta):
+        return '# objs in cache (delta): %s' % obj_delta
+
+    def format_duration(self, duration):
+        return 'Duration: %.2fs' % duration
+
+    def format_stats_line(self, data):
+        line = "%-20s %-30s %s" % (
+            self.format_duration(data['duration']),
+            self.format_rss_delta(data['rss_delta']),
+            self.format_obj_delta(data['obj_delta'])
+        )
+        return line
+
+    def display_current_stats(self):
+        log.info('Current RSS: %.2f MiB' % (self.get_rss() / 1024.0))
+        log.info('Current cache size (# objs): %s' %
+                 self.get_cache_size())
+        log.info('Current estimated cache size (MiB): %.2f' % (
+            self.get_estimated_size() / 1024.0 / 1024.0))
+        log.info('')
+
+    def display_summary(self):
+        """Log a summary of detailed collected delta stats.
+        """
+        log.info('')
+        log.info('Stats (deltas)')
+
+        log.info('')
+        log.info('Metadata stats')
+        data = self.stats_by_idx['warmup_metadata']['total']
+        log.info('Metadata warmup took %.2fs.' % data['duration'])
+        log.info('Instance memory growth: %s' %
+                 self.format_rss_delta(data['rss_delta']))
+        log.info('Cache size growth: %s' %
+                 self.format_obj_delta(data['obj_delta']))
+
+        log.info('')
+        log.info('Per index stats')
+        for index_name, data in self.stats_by_idx['warmup_index'].items():
+            log.info("Index: %-25s %s " % (
+                index_name, self.format_stats_line(data)))
+
+        log.info('')
+        log.info('Per lexicon stats')
+        for lexicon_name, data in self.stats_by_idx['warmup_lexicon'].items():
+            log.info("Lexicon: %-20s %s" % (
+                lexicon_name, self.format_stats_line(data)))
+
+        data = self.stats_by_idx['warmup_catalog']['total']
+        log.info('')
+        log.info('Catalog warmup took %.2fs.' % data['duration'])
+        log.info('Instance memory growth: %s' %
+                 self.format_rss_delta(data['rss_delta']))
+        log.info('Cache size growth: %s' %
+                 self.format_obj_delta(data['obj_delta']))
 
 
 class WarmupView(BrowserView):
@@ -69,10 +213,12 @@ class WarmupView(BrowserView):
             elif mode == 'medium':
                 self._warmup_medium()
             elif mode == 'catalog':
+                self.cache_stats = CacheStats(conn)
                 self._warmup_catalog(
                     zctext_indexes=zctext_indexes, lexicons=lexicons)
             else:
-                raise Exception('Warmup mode {!r} not recognized!'.format(mode))
+                raise Exception(
+                    'Warmup mode {!r} not recognized!'.format(mode))
 
             log.info('Done warming up.')
         return 'OK'
@@ -101,113 +247,107 @@ class WarmupView(BrowserView):
         self._warmup_minimal()
 
     def _warmup_catalog(self, zctext_indexes=True, lexicons=True):
-        start = time.time()
-
-        self._log_cache_stats('before warmup')
-        warmup_catalog(
-            self.catalog, zctext_indexes=zctext_indexes, lexicons=lexicons)
-        self._log_cache_stats('after warmup')
-
-        duration = time.time() - start
-        log.info("Catalog warmup took %.2fs." % duration)
-
-    def _log_cache_stats(self, when):
-        conn = self.context._p_jar
-        db = conn.db()
         log.info('')
-        log.info("Cache size (# objs) (%s): %s" % (when, db.cacheSize()))
-        log.info("Total estimated cache size (%s): %.2f MiB" %
-                 (when, conn._cache.total_estimated_size / 1024.0 / 1024.0))
-        log.info("Current instance RSS (%s): %.2f MiB" % (
-            when, get_rss() / 1024.0))
+        log.info('Stats before warmup (absolute):')
+        self.cache_stats.display_current_stats()
+
+        self.warmup_catalog(zctext_indexes=zctext_indexes, lexicons=lexicons)
+        self.cache_stats.display_summary()
+
         log.info('')
+        log.info('Stats after warmup (absolute):')
+        self.cache_stats.display_current_stats()
 
+    @CacheStats.track
+    def warmup_catalog(self, zctext_indexes=True, lexicons=True):
+        log.info('Loading metadata...')
+        self.warmup_metadata()
 
-def warmup_catalog(catalog, zctext_indexes=True, lexicons=True):
-    log.info('Loading metadata...')
-    list(catalog._catalog.data.items())
+        log.info('Loading indexes...')
+        for index_name in self.catalog.indexes():
+            index = self.catalog._catalog.indexes[index_name]
+            if not zctext_indexes and isinstance(index, ZCTextIndex):
+                continue
+            log.info('Loading index %r...' % index_name)
+            self.warmup_index(index, lexicons=lexicons)
 
-    log.info('Loading indexes...')
-    for index_name in catalog.indexes():
-        index = catalog._catalog.indexes[index_name]
-        if not zctext_indexes and isinstance(index, ZCTextIndex):
-            continue
-        log.info('Loading index %r...' % index_name)
-        warmup_index(index, lexicons=lexicons)
+        log.info('Done warming up catalog.')
 
-    log.info('Done warming up catalog.')
+    @CacheStats.track
+    def warmup_metadata(self):
+        list(self.catalog._catalog.data.items())
 
+    @CacheStats.track
+    def warmup_index(self, index, lexicons=True):
+        """Load internal index data structures by iterating over contents of
+        *BTrees and *TreeSets, causing their respective buckets to be loaded.
+        """
+        if isinstance(index, (FieldIndex, DateIndex, KeywordIndex)):
+            # value -> set of docids
+            for key, value in index._index.items():
+                list(value)
 
-def warmup_index(index, lexicons=True):
-    """Load internal index data structures by iterating over contents of
-    *BTrees and *TreeSets, causing their respective buckets to be loaded.
-    """
-    if isinstance(index, (FieldIndex, DateIndex, KeywordIndex)):
-        # value -> set of docids
-        for key, value in index._index.items():
-            list(value)
+            # docid -> field value
+            list(index._unindex.items())
 
-        # docid -> field value
-        list(index._unindex.items())
+        elif isinstance(index, ZCTextIndex):
+            # wid -> doc2score
+            list(index.index._wordinfo.items())
+            # docid -> docweight
+            list(index.index._docweight.items())
+            # docid -> encoded wordids
+            list(index.index._docwords.items())
 
-    elif isinstance(index, ZCTextIndex):
-        # wid -> doc2score
-        list(index.index._wordinfo.items())
-        # docid -> docweight
-        list(index.index._docweight.items())
-        # docid -> encoded wordids
-        list(index.index._docwords.items())
+            if lexicons:
+                self.warmup_lexicon(index)
 
-        if lexicons:
-            warmup_lexicon(index)
+        elif isinstance(index, BooleanIndex):
+            list(index._index)
+            list(index._unindex.items())
 
-    elif isinstance(index, BooleanIndex):
-        list(index._index)
-        list(index._unindex.items())
+        elif isinstance(index, ExtendedPathIndex):
+            # path component -> level -> set of docids
+            for comp, index_comp in index._index.items():
+                for level, docids_set in index_comp.items():
+                    list(docids_set)
 
-    elif isinstance(index, ExtendedPathIndex):
-        # path component -> level -> set of docids
-        for comp, index_comp in index._index.items():
-            for level, docids_set in index_comp.items():
+            # path -> set of docids
+            for path, docids_set in index._index_parents.items():
                 list(docids_set)
 
-        # path -> set of docids
-        for path, docids_set in index._index_parents.items():
-            list(docids_set)
+            # path -> docid
+            for path, docid in index._index_items.items():
+                assert isinstance(docid, int)
 
-        # path -> docid
-        for path, docid in index._index_items.items():
-            assert isinstance(docid, int)
+            # docid -> path
+            for docid, path in index._unindex.items():
+                assert isinstance(docid, int)
 
-        # docid -> path
-        for docid, path in index._unindex.items():
-            assert isinstance(docid, int)
+        elif isinstance(index, DateRangeIndex):
+            # no forward index
+            for docid, date_range in index._unindex.items():
+                assert isinstance(docid, int)
 
-    elif isinstance(index, DateRangeIndex):
-        # no forward index
-        for docid, date_range in index._unindex.items():
-            assert isinstance(docid, int)
+        elif isinstance(index, GopipIndex):
+            # not a real index
+            return
 
-    elif isinstance(index, GopipIndex):
-        # not a real index
-        return
+        elif isinstance(index, UUIDIndex):
+            list(index._index.items())
+            list(index._unindex.items())
 
-    elif isinstance(index, UUIDIndex):
-        list(index._index.items())
-        list(index._unindex.items())
+        else:
+            log.warn('Unexpected index type %r for index %r, skipping.' %
+                     (index.__class__, index.id))
 
-    else:
-        log.warn('Unexpected index type %r for index %r, skipping.' %
-                 (index.__class__, index.id))
+    @CacheStats.track
+    def warmup_lexicon(self, zc_text_index):
+        lexicon = aq_base(zc_text_index.index._lexicon)
+        log.info('Loading lexicon %r for index %r...' % (
+            lexicon.id, zc_text_index.id))
 
+        # word -> wid
+        list(lexicon._wids.items())
 
-def warmup_lexicon(zc_text_index):
-    lexicon = aq_base(zc_text_index.index._lexicon)
-    log.info('Loading lexicon %r for index %r...' % (
-        lexicon.id, zc_text_index.id))
-
-    # word -> wid
-    list(lexicon._wids.items())
-
-    # wid -> word
-    list(lexicon._words.items())
+        # wid -> word
+        list(lexicon._words.items())

--- a/opengever/maintenance/browser/warmup.py
+++ b/opengever/maintenance/browser/warmup.py
@@ -1,3 +1,4 @@
+from Acquisition import aq_base
 from opengever.contact.contact import IContact
 from opengever.document.behaviors import IBaseDocument
 from opengever.dossier.behaviors.dossier import IDossierMarker
@@ -7,9 +8,20 @@ from opengever.repository.repositoryroot import IRepositoryRoot
 from opengever.task.task import ITask
 from opengever.tasktemplates.content.tasktemplate import ITaskTemplate
 from plone import api
+from plone.app.folder.nogopip import GopipIndex
+from Products.ExtendedPathIndex.ExtendedPathIndex import ExtendedPathIndex
 from Products.Five.browser import BrowserView
+from Products.PluginIndexes.BooleanIndex.BooleanIndex import BooleanIndex
+from Products.PluginIndexes.DateIndex.DateIndex import DateIndex
+from Products.PluginIndexes.DateRangeIndex.DateRangeIndex import DateRangeIndex
+from Products.PluginIndexes.FieldIndex.FieldIndex import FieldIndex
+from Products.PluginIndexes.KeywordIndex.KeywordIndex import KeywordIndex
+from Products.PluginIndexes.UUIDIndex.UUIDIndex import UUIDIndex
+from Products.ZCTextIndex.ZCTextIndex import ZCTextIndex
 import logging
+import time
 import transaction
+import threading
 
 log = logging.getLogger('opengever.maintenance')
 
@@ -33,9 +45,15 @@ class WarmupView(BrowserView):
         # XXX: Check for filesystem token or ManagePortal permission
         transaction.doom()
         self.catalog = api.portal.get_tool('portal_catalog')
+        thread = threading.current_thread().name
+        conn = self.context._p_jar
 
         mode = self.request.form.get('mode', 'minimal')
-        log.info('Warming up instance (mode == {})...'.format(mode))
+        lexicons = self._to_bool(self.request.form.get('lexicons', True))
+
+        log.info(
+            'Warming up instance (mode == {}, Thread {!r}, '
+            'Connection {!r})...'.format(mode, thread, conn))
 
         if mode == 'minimal':
             self._warmup_minimal()
@@ -43,11 +61,16 @@ class WarmupView(BrowserView):
             self._warmup_medium()
         elif mode == 'full':
             self._warmup_full()
+        elif mode == 'catalog':
+            self._warmup_catalog(lexicons=lexicons)
         else:
             raise Exception('Warmup mode {!r} not recognized!'.format(mode))
 
         log.info('Done warming up.')
         return 'OK'
+
+    def _to_bool(self, value):
+        return str(value).lower() not in ('false', '0')
 
     def _warmup_minimal(self):
         # Fetch repository brains and objects
@@ -81,3 +104,110 @@ class WarmupView(BrowserView):
 
         self._warmup_medium()
         self._warmup_minimal()
+
+    def _warmup_catalog(self, lexicons=True):
+        start = time.time()
+
+        self._log_cache_stats('before warmup')
+        warmup_catalog(self.catalog, lexicons=lexicons)
+        self._log_cache_stats('after warmup')
+
+        duration = time.time() - start
+        log.info("Catalog warmup took %.2fs." % duration)
+
+    def _log_cache_stats(self, when):
+        conn = self.context._p_jar
+        db = conn.db()
+        log.info('')
+        log.info("Cache size (# objs) (%s): %s" % (when, db.cacheSize()))
+        log.info("Total estimated cache size (%s): %.2f MiB" %
+                 (when, conn._cache.total_estimated_size / 1024.0 / 1024.0))
+        log.info('')
+
+
+def warmup_catalog(catalog, lexicons=True):
+    log.info('Loading metadata...')
+    list(catalog._catalog.data.items())
+
+    log.info('Loading indexes...')
+    for index_name in catalog.indexes():
+        log.info('Loading index %r...' % index_name)
+        index = catalog._catalog.indexes[index_name]
+        warmup_index(index, lexicons=lexicons)
+
+    log.info('Done warming up catalog.')
+
+
+def warmup_index(index, lexicons=True):
+    """Load internal index data structures by iterating over contents of
+    *BTrees and *TreeSets, causing their respective buckets to be loaded.
+    """
+    if isinstance(index, (FieldIndex, DateIndex, KeywordIndex)):
+        # value -> set of docids
+        for key, value in index._index.items():
+            list(value)
+
+        # docid -> field value
+        list(index._unindex.items())
+
+    elif isinstance(index, ZCTextIndex):
+        # wid -> doc2score
+        list(index.index._wordinfo.items())
+        # docid -> docweight
+        list(index.index._docweight.items())
+        # docid -> encoded wordids
+        list(index.index._docwords.items())
+
+        if lexicons:
+            warmup_lexicon(index)
+
+    elif isinstance(index, BooleanIndex):
+        list(index._index)
+        list(index._unindex.items())
+
+    elif isinstance(index, ExtendedPathIndex):
+        # path component -> level -> set of docids
+        for comp, index_comp in index._index.items():
+            for level, docids_set in index_comp.items():
+                list(docids_set)
+
+        # path -> set of docids
+        for path, docids_set in index._index_parents.items():
+            list(docids_set)
+
+        # path -> docid
+        for path, docid in index._index_items.items():
+            assert isinstance(docid, int)
+
+        # docid -> path
+        for docid, path in index._unindex.items():
+            assert isinstance(docid, int)
+
+    elif isinstance(index, DateRangeIndex):
+        # no forward index
+        for docid, date_range in index._unindex.items():
+            assert isinstance(docid, int)
+
+    elif isinstance(index, GopipIndex):
+        # not a real index
+        return
+
+    elif isinstance(index, UUIDIndex):
+        list(index._index.items())
+        list(index._unindex.items())
+
+    else:
+        log.warn('Unexpected index type %r for index %r, skipping.' %
+                 (index.__class__, index.id))
+
+
+def warmup_lexicon(zc_text_index):
+    lexicon = aq_base(zc_text_index.index._lexicon)
+    log.info('Loading lexicon %r for index %r...' % (
+        lexicon.id, zc_text_index.id))
+
+    # word -> wid
+    list(lexicon._wids.items())
+
+    # wid -> word
+    list(lexicon._words.items())

--- a/opengever/maintenance/browser/warmup.py
+++ b/opengever/maintenance/browser/warmup.py
@@ -208,6 +208,9 @@ class WarmupView(BrowserView):
             log.info(
                 'Warming up instance (mode == {}, Thread {!r}, '
                 'Connection {!r})...'.format(mode, thread, conn))
+            log.info(
+                'Warmup settings: zctext_indexes={!r} lexicons={!r} unindexes={!r} '.format(
+                    zctext_indexes, lexicons, unindexes))
 
             if mode == 'minimal':
                 self._warmup_minimal()

--- a/opengever/maintenance/browser/warmup.py
+++ b/opengever/maintenance/browser/warmup.py
@@ -59,8 +59,6 @@ class WarmupView(BrowserView):
             self._warmup_minimal()
         elif mode == 'medium':
             self._warmup_medium()
-        elif mode == 'full':
-            self._warmup_full()
         elif mode == 'catalog':
             self._warmup_catalog(lexicons=lexicons)
         else:
@@ -89,20 +87,6 @@ class WarmupView(BrowserView):
             log.info('Fetched {} brains for type {}'.format(
                 count, type_iface.__identifier__))
 
-        self._warmup_minimal()
-
-    def _warmup_full(self):
-        # Fetch brains and objects for all common types
-        for type_iface in COMMON_TYPES:
-            count = 0
-            brains = self.catalog(object_provides=type_iface.__identifier__)
-            for brain in brains:
-                obj = brain.getObject()
-                count += 1
-            log.info('Fetched {} brains and objects for type {}'.format(
-                count, type_iface.__identifier__))
-
-        self._warmup_medium()
         self._warmup_minimal()
 
     def _warmup_catalog(self, lexicons=True):

--- a/opengever/maintenance/browser/warmup.py
+++ b/opengever/maintenance/browser/warmup.py
@@ -4,6 +4,7 @@ from opengever.document.behaviors import IBaseDocument
 from opengever.dossier.behaviors.dossier import IDossierMarker
 from opengever.inbox.forwarding import IForwarding
 from opengever.maintenance.utils import elevated_privileges
+from opengever.maintenance.utils import get_rss
 from opengever.repository.interfaces import IRepositoryFolder
 from opengever.repository.repositoryroot import IRepositoryRoot
 from opengever.task.task import ITask
@@ -117,6 +118,8 @@ class WarmupView(BrowserView):
         log.info("Cache size (# objs) (%s): %s" % (when, db.cacheSize()))
         log.info("Total estimated cache size (%s): %.2f MiB" %
                  (when, conn._cache.total_estimated_size / 1024.0 / 1024.0))
+        log.info("Current instance RSS (%s): %.2f MiB" % (
+            when, get_rss() / 1024.0))
         log.info('')
 
 

--- a/opengever/maintenance/utils.py
+++ b/opengever/maintenance/utils.py
@@ -5,6 +5,8 @@ from AccessControl.User import UnrestrictedUser as BaseUnrestrictedUser
 from contextlib import contextmanager
 from plone import api
 from zope.globalrequest import getRequest
+import os
+import subprocess
 
 
 def join_lines(fn):
@@ -13,6 +15,17 @@ def join_lines(fn):
     def wrapped(self, *args, **kwargs):
         return '\n'.join(fn(self, *args, **kwargs))
     return wrapped
+
+
+def get_rss():
+    """Get current memory usage (RSS) of this process.
+    """
+    out = subprocess.check_output(
+        ["ps", "-p", "%s" % os.getpid(), "-o", "rss"])
+    try:
+        return int(out.splitlines()[-1].strip())
+    except ValueError:
+        return 0
 
 
 class UnrestrictedUser(BaseUnrestrictedUser):


### PR DESCRIPTION
Adds `?mode=catalog` to the warmup view.

This will load all of the **catalog's internal data structures**.

The query string parameter `zctext_indexes=0` can be appended to avoid loading `ZCTextIndexes`, or `lexicons=0` to just avoid loading their lexicons.

Some **cache related statistics** will be displayed before and after the catalog warmup (total estimated cache size in bytes, number of objects in cache, current instance RSS).

In addition, the view will now run with **elevated privileges** (in order to be able to load actual objects, which are restricted by security, unlike catalog results), and `unrestrictedSearchResults` is being used for catalog queries.

I also dropped the `full` mode which was simply overkill (basically loading every single object on a GEVER instance).

----

Some stats from the `ogg100k` deployment:

`portal_catalog` ZEXP Size: `573M` (250k: 1.6G)

Catalog warmup (with lexicons):

```
2017-11-16T21:45:21 INFO opengever.maintenance Cache size (# objs) (before warmup): 82
2017-11-16T21:45:21 INFO opengever.maintenance Total estimated cache size (before warmup): 0.08 MiB

2017-11-16T21:58:04 INFO opengever.maintenance Cache size (# objs) (after warmup): 2170379
2017-11-16T21:58:04 INFO opengever.maintenance Total estimated cache size (after warmup): 999.25 MiB

2017-11-16T21:58:04 INFO opengever.maintenance Catalog warmup took 762.75s.
```

RSS of instance after warmup: 3576.8 MiB (264.5 before) => **+3312.3 MiB**
Warmup time: `12m 42s`

---

Catalog warmup (without lexicons):

```
2017-11-16T22:03:50 INFO opengever.maintenance Cache size (# objs) (before warmup): 82
2017-11-16T22:03:50 INFO opengever.maintenance Total estimated cache size (before warmup): 0.08 MiB

2017-11-16T22:15:51 INFO opengever.maintenance Cache size (# objs) (after warmup): 2047713
2017-11-16T22:15:51 INFO opengever.maintenance Total estimated cache size (after warmup): 908.05 MiB

2017-11-16T22:15:51 INFO opengever.maintenance Catalog warmup took 720.88s.
```

RSS of instance after warmup: 3267.6 MiB (264.4 before) => **+3003.2 MiB**
Warmup time: `12m 1s`


---

Catalog warmup (without ZCTextIndexes):

```
2017-11-17T14:11:10 INFO opengever.maintenance Cache size (# objs) (before warmup): 82
2017-11-17T14:11:10 INFO opengever.maintenance Total estimated cache size (before warmup): 0.08 MiB

2017-11-17T14:22:44 INFO opengever.maintenance Cache size (# objs) (after warmup): 1949361
2017-11-17T14:22:44 INFO opengever.maintenance Total estimated cache size (after warmup): 559.98 MiB

2017-11-17T14:22:44 INFO opengever.maintenance Catalog warmup took 694.73s.
```

RSS of instance after warmup: 2079.65 MiB (264.4 before) => **+1815.25 MiB**
Warmup time: `11m 35s`


