### PR TITLE
Catch transient buildout failures easier on local runs

### DIFF
--- a/test_all.sh
+++ b/test_all.sh
@@ -2,6 +2,8 @@
 #
 # Helper script to LOCALLY test opengever.maintenance with all test-*.cfgs
 
+set -euo pipefail
+
 PYTHON="python2.7"
 
 for CFG in test-og-*


### PR DESCRIPTION
Buildout still trips up on itself quite often when having to downgrade itself. Catching this early in a non-interactive local test run is IMO useful.