### PR TITLE
Add fix_one_note_mimetype script.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 1.0 (unreleased)
 ----------------
 
+- Add fix_one_note_mimetype script. [phgross]
+
 - Ungrok opengever.maintenance. [elioschmutz]
 
 - Add script to fix broken journal entries after OGGBundle import. [phgross]

--- a/opengever/maintenance/scripts/fix_one_note_mimetypes.py
+++ b/opengever/maintenance/scripts/fix_one_note_mimetypes.py
@@ -1,0 +1,51 @@
+from opengever.document.document import IDocumentSchema
+from opengever.maintenance.debughelpers import setup_app
+from opengever.maintenance.debughelpers import setup_option_parser
+from opengever.maintenance.debughelpers import setup_plone
+from os.path import splitext
+from plone import api
+import transaction
+
+
+def fix_one_note_mimetype():
+    """Search all MS OneNote documents and fixes the contentType.
+    """
+
+    catalog = api.portal.get_tool('portal_catalog')
+    for brain in catalog.unrestrictedSearchResults(
+            {'object_provides': IDocumentSchema.__identifier__}):
+
+        if brain.getContentType == 'application/octet-stream':
+            obj = brain.getObject()
+            if not obj.file:
+                continue
+
+            filename, ext = splitext(obj.file.filename)
+            if ext == '.one':
+                obj.file.contentType = 'application/onenote'
+                obj.reindexObject()
+
+                print u'File {} with {} fixed.'.format(obj, obj.file.filename)
+
+
+def main():
+    app = setup_app()
+
+    parser = setup_option_parser()
+    parser.add_option("-n", dest="dry_run", action="store_true", default=False)
+    (options, args) = parser.parse_args()
+
+    setup_plone(app, options)
+
+    if options.dry_run:
+        transaction.doom()
+        print "DRY-RUN"
+
+    fix_one_note_mimetype()
+
+    if not options.dry_run:
+        transaction.commit()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
With https://github.com/4teamwork/opengever.core/pull/3660 the mimetype for onenote document has been fixed. But the fix in #3660 solves the problem only for new but not for existing documents. Because we don't have an index for the contentType or the filename an upgradestep would be way to longrunning comparing how many documents are effected. Therefore we add this simple opengever.maintenance script. We can run offside the release.