### PR TITLE
Bump 2018.3.x tests to 2018.3.2

### DIFF
--- a/test-og-2018.3.x.cfg
+++ b/test-og-2018.3.x.cfg
@@ -1,5 +1,5 @@
 [buildout]
 extends =
     https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
-    https://raw.githubusercontent.com/4teamwork/opengever.core/2018.3.1/versions.cfg
+    https://raw.githubusercontent.com/4teamwork/opengever.core/2018.3.2/versions.cfg
     base-testing.cfg


### PR DESCRIPTION
Bump `2018.3.x` tests to `2018.3.2`.