### PR TITLE
Enhance find_non_persisted_values.py script

### DIFF
--- a/opengever/maintenance/scripts/find_non_persisted_values.py
+++ b/opengever/maintenance/scripts/find_non_persisted_values.py
@@ -1,12 +1,15 @@
 """
 Script to find field values that haven't been persisted on objects.
 
-    bin/instance run find_non_persisted_values.py > nonpersistent.csv
+    bin/instance run find_non_persisted_values.py
 
-This script produces a CSV file on STDOUT (and some progress info on STDERR).
-
+This script logs a detailed CSV report and a summary to var/log/, and displays
+some progress info and stats on STDERR/STDOUT.
 """
+
+from App.config import getConfiguration
 from collections import Counter
+from datetime import datetime
 from opengever.base.default_values import get_persisted_value_for_field
 from opengever.maintenance.debughelpers import setup_app
 from opengever.maintenance.debughelpers import setup_option_parser
@@ -17,8 +20,13 @@ from plone.dexterity.utils import iterSchemataForType
 from zope.component import getUtility
 from zope.intid.interfaces import IIntIds
 from zope.schema import getFieldsInOrder
+import logging
+import os
 import sys
 import transaction
+
+
+root_logger = logging.root
 
 
 class NonPersistedValueFinder(object):
@@ -34,24 +42,34 @@ class NonPersistedValueFinder(object):
         self.stats = Counter()
         self.stats['by_field'] = Counter()
 
+        ts = datetime.today().strftime('%Y-%m-%d_%H-%M-%S')
+        self.csv_log_path = self.get_logfile_path(
+            'find-nonpersistent-values-%s.csv' % ts)
+        self.summary_log_path = self.get_logfile_path(
+            'find-nonpersistent-values-summary-%s.log' % ts)
+
     def run(self):
         sys.stderr.write("Checking for non-persisted values...\n\n")
 
         all_brains = self.catalog.unrestrictedSearchResults()
         total = len(all_brains)
 
-        for i, brain in enumerate(all_brains):
-            obj = brain.getObject()
-            missing_fields = self.check_for_missing_fields(obj)
-            self.update_stats(missing_fields)
+        with open(self.csv_log_path, 'w') as self.csv_log:
+            with open(self.summary_log_path, 'w') as self.summary_log:
+                self.csv_log.write(self.CSV_HEADER + '\n')
 
-            if missing_fields:
-                self.write_csv_row(obj, missing_fields)
+                for i, brain in enumerate(all_brains):
+                    obj = brain.getObject()
+                    missing_fields = self.check_for_missing_fields(obj)
+                    self.update_stats(missing_fields)
 
-            if i % 100 == 0:
-                sys.stderr.write("Progress: %s of %s objects\n" % (i, total))
+                    if missing_fields:
+                        self.write_csv_row(obj, missing_fields)
 
-        self.display_stats()
+                    if i % 100 == 0:
+                        sys.stderr.write("Progress: %s of %s objects\n" % (i, total))
+
+                self.display_stats()
 
     def check_for_missing_fields(self, obj):
         missing_fields = []
@@ -100,7 +118,7 @@ class NonPersistedValueFinder(object):
             created,
             str([f[1] for f in missing_fields]),
         ]
-        print ';'.join(row)
+        self.csv_log.write(';'.join(row) + '\n')
 
     def update_stats(self, missing_fields):
         if missing_fields:
@@ -112,19 +130,54 @@ class NonPersistedValueFinder(object):
             self.stats['ok'] += 1
 
     def display_stats(self):
-        sys.stderr.write("\n")
 
-        sys.stderr.write("Missing (by field):\n")
+        def log(line):
+            sys.stdout.write(line)
+            self.summary_log.write(line)
+
+        log("\n")
+
+        log("Missing (by field):\n")
         stats_by_field = sorted(self.stats['by_field'].items())
         for (schema_name, field_name), count in stats_by_field:
             dotted_name = '.'.join((schema_name, field_name))
-            sys.stderr.write("  %-120s %s\n" % (dotted_name, count))
+            log("  %-120s %s\n" % (dotted_name, count))
 
-        sys.stderr.write("\n")
+        log("\n")
 
-        sys.stderr.write("Summary (by object):\n")
-        sys.stderr.write("Missing: %s\n" % self.stats['missing'])
-        sys.stderr.write("OK: %s\n" % self.stats['ok'])
+        log("Summary (by object):\n")
+        log("Missing: %s\n" % self.stats['missing'])
+        log("OK: %s\n" % self.stats['ok'])
+
+        log("\n")
+        log("Detailed CSV report written to %s\n" % self.csv_log_path)
+        log("Summary written to %s\n" % self.summary_log_path)
+
+    def get_logfile_path(self, filename):
+        log_dir = self.get_logdir()
+        return os.path.join(log_dir, filename)
+
+    def get_logdir(self):
+        """Determine the log directory.
+        This will be derived from Zope2's EventLog location, in order to not
+        have to figure out the path to var/log/ ourselves.
+        """
+        zconf = getConfiguration()
+        eventlog = getattr(zconf, 'eventlog', None)
+
+        if eventlog is None:
+            root_logger.error('')
+            root_logger.error(
+                "Couldn't find eventlog configuration in order to determine "
+                "logfile location - aborting!")
+            root_logger.error('')
+            sys.exit(1)
+
+        handler_factories = eventlog.handler_factories
+        eventlog_path = handler_factories[0].section.path
+        assert eventlog_path.endswith('.log')
+        log_dir = os.path.dirname(eventlog_path)
+        return log_dir
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
These are a couple enhancements to the `find_non_persisted_values.py` script in preparation for a script to actually **fix** the nonpersisted values:

- Make the script object oriented for better maintainability and readability
- Also log `portal_type` of the affected objects
- Also log detected missing values **by field** to get a better overview of what specific fields are affected
- Make sure logs are automatically written to files in `var/log` (both the summary as well as the detailed CSV report).

@phgross I tried to make sensible commits, but the diff may be a bit hard to read for this one. Maybe easier to look at the finished script as a whole.