### PR TITLE
Bump 2018.4 tests to latest hotfix release.

### DIFF
--- a/test-og-2018.4.x.cfg
+++ b/test-og-2018.4.x.cfg
@@ -1,5 +1,5 @@
 [buildout]
 extends =
     https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
-    https://raw.githubusercontent.com/4teamwork/opengever.core/2018.4.0/versions.cfg
+    https://raw.githubusercontent.com/4teamwork/opengever.core/2018.4.1/versions.cfg
     base-testing.cfg


### PR DESCRIPTION
opengever.core 2018.4.1 has been released.