### PR TITLE
Monitor server

### DIFF
--- a/opengever/maintenance/browser/warmup.py
+++ b/opengever/maintenance/browser/warmup.py
@@ -30,29 +30,37 @@ WARMUP_INDEXES = [
     'object_provides',
 ]
 
+warmup_in_progress = False
+
 
 class WarmupView(BrowserView):
     """View to warm up a GEVER instance.
     """
 
     def __call__(self):
-        # XXX: Check for filesystem token or ManagePortal permission
-        transaction.doom()
-        self.catalog = api.portal.get_tool('portal_catalog')
+        global warmup_in_progress
+        warmup_in_progress = True
 
-        mode = self.request.form.get('mode', 'minimal')
-        log.info('Warming up instance (mode == {})...'.format(mode))
+        try:
+            transaction.doom()
+            self.catalog = api.portal.get_tool('portal_catalog')
 
-        if mode == 'minimal':
-            self._warmup_minimal()
-        elif mode == 'medium':
-            self._warmup_medium()
-        elif mode == 'full':
-            self._warmup_full()
-        elif mode == 'catalog':
-            self._warmup_catalog()
-        else:
-            raise Exception('Warmup mode {!r} not recognized!'.format(mode))
+            mode = self.request.form.get('mode', 'minimal')
+            log.info('Warming up instance (mode == {})...'.format(mode))
+
+            if mode == 'minimal':
+                self._warmup_minimal()
+            elif mode == 'medium':
+                self._warmup_medium()
+            elif mode == 'full':
+                self._warmup_full()
+            elif mode == 'catalog':
+                self._warmup_catalog()
+            else:
+                raise Exception('Warmup mode {!r} not recognized!'.format(mode))
+
+        finally:
+            warmup_in_progress = False
 
         log.info('Done warming up.')
         return 'OK'

--- a/opengever/maintenance/configure.zcml
+++ b/opengever/maintenance/configure.zcml
@@ -14,5 +14,6 @@
     <includeDependencies package="." />
 
     <include package=".browser" />
+    <include package=".monitor" />
 
 </configure>

--- a/opengever/maintenance/monitor/configure.zcml
+++ b/opengever/maintenance/monitor/configure.zcml
@@ -1,0 +1,13 @@
+<configure xmlns="http://namespaces.zope.org/zope"
+           xmlns:browser="http://namespaces.zope.org/browser"
+           i18n_domain="collective.monitor">
+
+    <include package="five.z2monitor"/>
+
+    <utility
+        component=".health.health_check"
+        provides="zc.z3monitor.interfaces.IZ3MonitorPlugin"
+        name="health_check"
+        />
+
+</configure>

--- a/opengever/maintenance/monitor/health.py
+++ b/opengever/maintenance/monitor/health.py
@@ -1,0 +1,20 @@
+from Zope2 import app as App
+
+
+def health_check(connection):
+    ok = True
+    app = App()
+    try:
+        dbchooser = app.Control_Panel.Database
+        for dbname in dbchooser.getDatabaseNames():
+            storage = dbchooser[dbname]._getDB()._storage
+            is_connected = getattr(storage, 'is_connected', None)
+            if is_connected is not None and not is_connected():
+                ok = False
+                connection.write(
+                    "Error: Database '{}'' disconnected.\n".format(dbname))
+    finally:
+        app._p_jar.close()
+
+    if ok:
+        connection.write('OK\n')

--- a/opengever/maintenance/monitor/health.py
+++ b/opengever/maintenance/monitor/health.py
@@ -1,4 +1,5 @@
 from Zope2 import app as App
+from opengever.maintenance.browser import warmup
 
 
 def health_check(connection):
@@ -15,6 +16,10 @@ def health_check(connection):
                     "Error: Database '{}'' disconnected.\n".format(dbname))
     finally:
         app._p_jar.close()
+
+    if warmup.warmup_in_progress:
+        ok = False
+        connection.write("Warmup in progress\n")
 
     if ok:
         connection.write('OK\n')

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(name='opengever.maintenance',
       zip_safe=False,
       install_requires=[
           'apachelog',
+          'five.z2monitor',
           'opengever.core',
           'Plone',
           'plone.api',


### PR DESCRIPTION
Implement monitor server for HAProxy health checks.

This allows us to run a single threaded ZServer per instance and do the HAProxy health checks with the monitor server using a different port.

The monitor server port needs to be configured in zope.conf. E.g.
```
zope-conf-additional +=
  <product-config five.z2monitor>
    bind 127.0.0.1:10181
  </product-config>
```
If not configured, the monitor server is not started.

