### PR TITLE
Improve solr activation and add a solr maintenance script

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 1.0 (unreleased)
 ----------------
 
+- Add solr-maintenance script. [phgross]
+
 - Add script to fix mail message caches. [lgraf]
 
 - Add script to list .url files. [lgraf]

--- a/opengever/maintenance/scripts/activate_solr.py
+++ b/opengever/maintenance/scripts/activate_solr.py
@@ -39,7 +39,7 @@ def main():
     portal = setup_plone(app, options)
     portal.REQUEST.response.stdout = StringIO()
     if not options.no_indexing:
-        reindex(portal)
+        sync(portal)
 
     # Abort current transaction after Solr reindexing because we didn't modify
     # any ZODB data and we don't want to retry the transaction because of a
@@ -56,11 +56,11 @@ def main():
     trx.commit()
 
 
-def reindex(portal):
-    logger.info('Reindexing Solr...')
+def sync(portal):
+    logger.info('Indexing Solr using sync mode')
     solr_maintenance = queryMultiAdapter(
         (portal, portal.REQUEST), name=u'solr-maintenance')
-    solr_maintenance.reindex()
+    solr_maintenance.sync()
     solr_maintenance.optimize()
 
 

--- a/opengever/maintenance/scripts/solr_maintenance.py
+++ b/opengever/maintenance/scripts/solr_maintenance.py
@@ -1,0 +1,38 @@
+from opengever.maintenance.debughelpers import setup_app
+from opengever.maintenance.debughelpers import setup_plone
+from StringIO import StringIO
+from zope.component import queryMultiAdapter
+import argparse
+import logging
+import sys
+
+
+logger = logging.getLogger('solr_maintenance')
+logging.getLogger().setLevel(logging.INFO)
+for handler in logging.getLogger().handlers:
+    handler.setLevel(logging.INFO)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('mode', choices=['reindex', 'sync', 'diff', 'clear'],
+                        help='solr-maintenance mode')
+    parser.add_argument('-s', dest='site_root', default=None,
+                        help='Absolute path to the Plone site')
+    options = parser.parse_args(sys.argv[3:])
+    app = setup_app()
+
+    portal = setup_plone(app, options)
+    portal.REQUEST.response.stdout = StringIO()
+
+    logger.info('Start solr maintenance mode `{}`'.format(options.mode))
+    solr_maintenance = queryMultiAdapter(
+        (portal, portal.REQUEST), name=u'solr-maintenance')
+    getattr(solr_maintenance, options.mode)()
+
+    if options.mode in ['reindex', 'sync']:
+        solr_maintenance.optimize()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
- Add solr-maintenance bin/instance run script, which allows to start solr-maintenance jobs from the shell. `reindex`, `clear`, `diff` and `sync` are the supported modes.
- Use sync mode in the solr activate script for indexing content.  So its also possible to reindex and prepare a large GEVER deployment for the solr activation and run the solr activation in a separate step.