### PR TITLE
Make import of five.z2monitor conditional.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 1.0 (unreleased)
 ----------------
 
+- Make import of five.z2monitor conditional. [njohner]
+
 - Add script to fix filenames with missing extensions. [njohner]
 
 - Add script to list proposals with no returned excerpt. [njohner]

--- a/opengever/maintenance/monitor/configure.zcml
+++ b/opengever/maintenance/monitor/configure.zcml
@@ -1,13 +1,15 @@
 <configure xmlns="http://namespaces.zope.org/zope"
            xmlns:browser="http://namespaces.zope.org/browser"
+           xmlns:zcml="http://namespaces.zope.org/zcml"
            i18n_domain="collective.monitor">
 
-    <include package="five.z2monitor"/>
-
-    <utility
-        component=".health.health_check"
-        provides="zc.z3monitor.interfaces.IZ3MonitorPlugin"
-        name="health_check"
-        />
+    <configure zcml:condition="installed five.z2monitor ">
+      <include package="five.z2monitor"/>
+      <utility
+          component=".health.health_check"
+          provides="zc.z3monitor.interfaces.IZ3MonitorPlugin"
+          name="health_check"
+          />
+    </configure>
 
 </configure>


### PR DESCRIPTION
As this is a new package, it would require a buildout of gever in order to use newer versions of opengever.maintenance.