### PR TITLE
Add tests for new release 2019.1.0, drop old tests.

### DIFF
--- a/test-og-2017.2.x.cfg
+++ b/test-og-2017.2.x.cfg
@@ -1,5 +1,0 @@
-[buildout]
-extends =
-    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
-    http://kgs.4teamwork.ch/release/opengever/2017.2.5
-    base-testing.cfg

--- a/test-og-2017.4.x.cfg
+++ b/test-og-2017.4.x.cfg
@@ -1,5 +1,0 @@
-[buildout]
-extends =
-    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
-    https://raw.githubusercontent.com/4teamwork/opengever.core/2017.4.1/versions.cfg
-    base-testing.cfg

--- a/test-og-2017.5.x.cfg
+++ b/test-og-2017.5.x.cfg
@@ -1,5 +1,0 @@
-[buildout]
-extends =
-    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
-    https://raw.githubusercontent.com/4teamwork/opengever.core/2017.5.1/versions.cfg
-    base-testing.cfg

--- a/test-og-2019.1.x.cfg
+++ b/test-og-2019.1.x.cfg
@@ -1,0 +1,5 @@
+[buildout]
+extends =
+    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
+    https://raw.githubusercontent.com/4teamwork/opengever.core/2019.1.0/versions.cfg
+    base-testing.cfg

--- a/test-og-3.10.x.cfg
+++ b/test-og-3.10.x.cfg
@@ -1,5 +1,0 @@
-[buildout]
-extends =
-    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
-    http://kgs.4teamwork.ch/release/opengever/3.10.3
-    base-testing.cfg

--- a/test-og-3.11.x.cfg
+++ b/test-og-3.11.x.cfg
@@ -1,5 +1,0 @@
-[buildout]
-extends =
-    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
-    http://kgs.4teamwork.ch/release/opengever/3.11.4
-    base-testing.cfg

--- a/test-og-3.7.x.cfg
+++ b/test-og-3.7.x.cfg
@@ -1,5 +1,0 @@
-[buildout]
-extends =
-    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
-    http://kgs.4teamwork.ch/release/opengever/3.7.0
-    base-testing.cfg


### PR DESCRIPTION
- Add a new test configuration to automatically test the latest 2019.1.x release.
- Drop tests for versions no longer used in production. `opengever.zug` is the oldest deployment, they are currently running on `2017.6.8`.