### PR TITLE
Stop executing opengever.core tests in test runner.

### DIFF
--- a/base-testing.cfg
+++ b/base-testing.cfg
@@ -11,7 +11,6 @@ package-namespace = opengever
 
 [test]
 arguments = ['-s', '${buildout:package-namespace}', '--exit-with-status', '--auto-color', '--auto-progress', '--xml', '--package-path', '${buildout:directory}/${buildout:package-namespace}', '${buildout:package-namespace}']
-eggs += opengever.core
 
 [versions]
 opengever.maintenance =

--- a/base-testing.cfg
+++ b/base-testing.cfg
@@ -9,9 +9,6 @@ find-links =
 package-name = opengever.maintenance
 package-namespace = opengever
 
-[test]
-arguments = ['-s', '${buildout:package-namespace}', '--exit-with-status', '--auto-color', '--auto-progress', '--xml', '--package-path', '${buildout:directory}/${buildout:package-namespace}', '${buildout:package-namespace}']
-
 [versions]
 opengever.maintenance =
 ftw.testing =

--- a/base-testing.cfg
+++ b/base-testing.cfg
@@ -7,7 +7,6 @@ find-links =
     http://psc.4teamwork.ch/simple
 
 package-name = opengever.maintenance
-package-namespace = opengever
 
 [versions]
 opengever.maintenance =


### PR DESCRIPTION
Catch up with changes to test-base configuration introduced in https://github.com/4teamwork/ftw-buildouts/pull/150.

We can now drop separate/additional configuration of the `[test]` section as the arguments provided in https://github.com/4teamwork/ftw-buildouts/pull/150 can be used.