### PR TITLE
Update the script to fix non persisted values for new fields and indexers.

### DIFF
--- a/opengever/maintenance/scripts/fix_non_persisted_values.py
+++ b/opengever/maintenance/scripts/fix_non_persisted_values.py
@@ -915,15 +915,15 @@ class Reindexer(object):
                            if name not in SAFE_INDEXERS and
                            name not in DEPENDENT_INDEXERS}
         if unsafe_indexers:
-            self.log("Obj has indexers not explicitly declared as safe:")
+            self.fixer.log("Obj has indexers not explicitly declared as safe:")
             for name, indexer in unsafe_indexers.items():
-                self.log("%s (%r, %r)" % (
+                self.fixer.log("%s (%r, %r)" % (
                     name, indexer.callable.__name__,
                     indexer.callable.__module__))
 
             # Fall back to doing a full metadata diff
-            self.log("Falling back to full metadata diff for %r "
-                     "(fields: %r)" % (obj.id, fixed_fieldnames))
+            self.fixer.log("Falling back to full metadata diff for %r "
+                           "(fields: %r)" % (obj.id, fixed_fieldnames))
             changed_columns = self.has_metadata_changed(obj, brain)
             if changed_columns:
                 return True

--- a/opengever/maintenance/scripts/fix_non_persisted_values.py
+++ b/opengever/maintenance/scripts/fix_non_persisted_values.py
@@ -229,6 +229,7 @@ SAFE_INDEXERS = [
     'Subject',
     'delivery_date',
     'document_date',
+    'has_sametype_children',
 
     'start',
     'responsible',

--- a/opengever/maintenance/scripts/fix_non_persisted_values.py
+++ b/opengever/maintenance/scripts/fix_non_persisted_values.py
@@ -230,6 +230,7 @@ SAFE_INDEXERS = [
     'delivery_date',
     'document_date',
     'has_sametype_children',
+    'changed',
 
     'start',
     'responsible',

--- a/opengever/maintenance/scripts/fix_non_persisted_values.py
+++ b/opengever/maintenance/scripts/fix_non_persisted_values.py
@@ -78,6 +78,7 @@ OPTIONAL_WITH_STATIC_DEFAULT = {
     ],
     'ITask': [
         'relatedItems',  # RelationList - default=[]
+        'revoke_permissions',  # Bool - default=True
     ],
     'ISubmittedProposal': [
         'excerpts',  # RelationList - default=[]


### PR DESCRIPTION
Update the script to fix non persisted values for new field `ITask.revoke_permissions` and indexers `opengever.base.indexes.has_sametype_children` and `opengever.base.indexes.changed`.

Also fix an issue with printing output to the console.