### PR TITLE
Fix value changed reporting, respect all fields.

### DIFF
--- a/opengever/maintenance/scripts/fix_non_persisted_values.py
+++ b/opengever/maintenance/scripts/fix_non_persisted_values.py
@@ -478,13 +478,14 @@ class NonPersistedValueFixer(object):
     def write_csv_row(self, obj, missing_fields):
         created = str(obj.created())
         intid = self.intids.queryId(obj)
+        values_changed = [f.value_changed for f in missing_fields]
         row = [
             str(intid),
             obj.portal_type,
             '/'.join(obj.getPhysicalPath()),
             created,
             str([f.field_name for f in missing_fields]),
-            str(f.value_changed),
+            str(any(values_changed)),
         ]
         self.csv_log.write(';'.join(row) + '\n')
 


### PR DESCRIPTION
Report if the value has changed in any field, not just the last field from the scope of the previous list comprehension.