### PR TITLE
Add nightly job and script to queue missing archival file conversions.

### DIFF
--- a/opengever/maintenance/configure.zcml
+++ b/opengever/maintenance/configure.zcml
@@ -16,4 +16,9 @@
     <include package=".browser" />
     <include package=".monitor" />
 
+  <adapter
+      factory=".nightly_archival_file_job.NightlyArchivalFileConversion"
+      name="trigger-missing-archival-file-conversion"
+      />
+
 </configure>

--- a/opengever/maintenance/nightly_archival_file_job.py
+++ b/opengever/maintenance/nightly_archival_file_job.py
@@ -1,0 +1,103 @@
+from opengever.document.archival_file import ArchivalFileConverter
+from opengever.nightlyjobs.interfaces import INightlyJobProvider
+from plone import api
+from Products.CMFPlone.interfaces import IPloneSiteRoot
+from time import sleep
+from zope.annotation import IAnnotations
+from zope.component import adapter
+from zope.component import getUtility
+from zope.interface import implementer
+from zope.intid.interfaces import IIntIds
+from zope.publisher.interfaces.browser import IBrowserRequest
+import logging
+
+
+MISSING_ARCHIVAL_FILE_KEY = 'DOCS_WITH_MISSING_ARCHIVAL_FILE'
+MAX_CONVERSION_REQUESTS_PER_NIGHT = 1000
+
+# Track total number of conversion requests sent per nightly run
+sent_conversion_requests = 0
+
+
+@implementer(INightlyJobProvider)
+@adapter(IPloneSiteRoot, IBrowserRequest, logging.Logger)
+class NightlyArchivalFileConversion(object):
+    """Trigger conversion of archival files for documents that have been put
+    in the persistent queue (by the `ArchivalFileChecker`).
+    """
+
+    def __init__(self, context, request, logger):
+        self.context = context
+        self.request = request
+        self.logger = logger
+
+        self.catalog = api.portal.get_tool('portal_catalog')
+        self.intids = getUtility(IIntIds)
+
+    def get_queue(self):
+        """The queue is a BTree in the site root's annotations.
+
+        It is a mapping of dossier IntIds to lists of document IntIds (the
+        documents being the ones that are missing their archival file).
+
+        It is grouped by dossier because this allows us to process the queue
+        in more reasonably sized chunks, instead of every single document
+        being considered a "job" (which would lead to a commit every time).
+
+        So the unit of work for this job is a dossier, and during the
+        execution of that job it will trigger the conversion for that dossiers
+        missing archival files.
+        """
+        ann = IAnnotations(self.context)
+        queue = ann.get(MISSING_ARCHIVAL_FILE_KEY, {})
+        return queue
+
+    def __iter__(self):
+        """Iterate over jobs, which as described above, are dossier IntIds.
+        """
+        queue = self.get_queue()
+        # Avoid list size changing during iteration
+        jobs = list(queue.keys())
+
+        for job in jobs:
+            self.logger.info('sent_conversion_requests: %r' % sent_conversion_requests)
+            if sent_conversion_requests >= MAX_CONVERSION_REQUESTS_PER_NIGHT:
+                self.logger.warn(
+                    "Reached MAX_CONVERSION_REQUESTS_PER_NIGHT "
+                    "(%r) limit, stopping work for tonight." %
+                    MAX_CONVERSION_REQUESTS_PER_NIGHT)
+                raise StopIteration
+
+            yield job
+
+    def __len__(self):
+        return len(self.get_queue())
+
+    def trigger_conversion(self, doc):
+        self.logger.info("Triggering conversion for %r" % doc)
+        ArchivalFileConverter(doc).trigger_conversion()
+
+    def run_job(self, job, interrupt_if_necessary):
+        """Run the job for the dossier identified by the IntId `job`.
+
+        This means getting all the document IntIds that this dossier IntIds
+        points to in the queue, and triggering conversion for those documents.
+        """
+        global sent_conversion_requests
+
+        dossier_intid = job
+        dossier = self.intids.getObject(dossier_intid)
+        self.logger.info("Triggering conversion jobs for documents in %r" % dossier)
+
+        queue = self.get_queue()
+        for doc_intid in queue[dossier_intid]:
+            interrupt_if_necessary()
+            doc = self.intids.getObject(doc_intid)
+            self.trigger_conversion(doc)
+            sent_conversion_requests += 1
+
+            # Stagger conversion requests at least a little bit, in order to
+            # avoid overloading Bumblebee. This likely will have to be tuned.
+            sleep(1)
+
+        queue.pop(dossier_intid)

--- a/opengever/maintenance/nightly_archival_file_job.py
+++ b/opengever/maintenance/nightly_archival_file_job.py
@@ -1,5 +1,4 @@
 from opengever.document.archival_file import ArchivalFileConverter
-from opengever.nightlyjobs.interfaces import INightlyJobProvider
 from plone import api
 from Products.CMFPlone.interfaces import IPloneSiteRoot
 from time import sleep
@@ -7,9 +6,19 @@ from zope.annotation import IAnnotations
 from zope.component import adapter
 from zope.component import getUtility
 from zope.interface import implementer
+from zope.interface import Interface
 from zope.intid.interfaces import IIntIds
 from zope.publisher.interfaces.browser import IBrowserRequest
 import logging
+
+# Conditional import to not cause issues on og.core versions where
+# opengever.nightlyjobs.interfaces doesn't exist yet
+try:
+    from opengever.nightlyjobs.interfaces import INightlyJobProvider
+except ImportError:
+    # Older og.core version - provide a dummy interface
+    class INightlyJobProvider(Interface):
+        pass
 
 
 MISSING_ARCHIVAL_FILE_KEY = 'DOCS_WITH_MISSING_ARCHIVAL_FILE'

--- a/opengever/maintenance/scripts/archival_file_checker.py
+++ b/opengever/maintenance/scripts/archival_file_checker.py
@@ -1,0 +1,368 @@
+"""
+Script that reports documents missing their archival file, and optionally
+queues them for conversion by a nightly job.
+
+Usage: archival_file_checker.py [-n] [report_missing | queue_missing]
+
+The script takes one of two commmands:
+
+report_missing
+    Reports all documents missing their archival file.
+
+queue_missing
+    Reports the documents, and additionally queues them for conversion by
+    a nightly job (by adding them to a persistent queue on the site root).
+
+The script will display some basic console output, and automatically log
+that ouput and some more detailed information to a logfile.
+"""
+from BTrees.IIBTree import IITreeSet
+from BTrees.IOBTree import IOBTree
+from collections import Counter
+from collections import OrderedDict
+from ftw.bumblebee.interfaces import IBumblebeeDocument
+from opengever.document.behaviors import IBaseDocument
+from opengever.dossier.behaviors.dossier import IDossierMarker
+from opengever.maintenance.debughelpers import setup_app
+from opengever.maintenance.debughelpers import setup_plone
+from opengever.maintenance.nightly_archival_file_job import MISSING_ARCHIVAL_FILE_KEY
+from opengever.maintenance.utils import LogFilePathFinder
+from opengever.maintenance.utils import TextTable
+from plone import api
+from Products.CMFPlone.interfaces import IPloneSiteRoot
+from zope.annotation import IAnnotations
+from zope.component import getUtility
+from zope.intid.interfaces import IIntIds
+import argparse
+import logging
+import sys
+import transaction
+
+
+logger = logging.getLogger('archival_file_checker')
+logger.setLevel(logging.INFO)
+
+
+class ArchivalFileChecker(object):
+    """Checks whether documents that should have an archival file actually
+    do have one, and reports the ones that don't.
+
+    With command 'queue_missing' also queues those documents for conversion
+    via a nightly job.
+    """
+
+    def __init__(self, context, options, logger):
+        self.context = context
+        self.options = options
+        self.logger = logger
+
+        self.log = logger.log
+        self.log_to_file = logger.log_to_file
+
+        self.catalog = api.portal.get_tool('portal_catalog')
+        self.all_dossier_stats = None
+
+    def run(self):
+        assert IPloneSiteRoot.providedBy(self.context)
+
+        missing_by_dossier = self.check()
+
+        if self.options.cmd == 'queue_missing':
+            self.queue_missing(missing_by_dossier)
+
+        self.log("")
+        self.log("Detailed log written to %s" % self.logger.logfile_path)
+
+    def check(self):
+        """For all candidate dossiers, check if the documents contained in
+        them are missing their archival file.
+
+        A candidate dossier is any dossier that:
+        - is resolved
+        - doesn't have any after-resolve jobs pending
+        - isn't a subdossier (we'll check docs recursively)
+
+        For each dossier we'll gather some stats that allow us to cross-check
+        that the script is operating correctly, even though in the end we
+        only really need a list of documents (per dossier) that are missing
+        their archival file.
+
+        Once done, we'll display (and log) a summary report. In addition,
+        a detailed list of the documents missing their archival file is
+        logged to the file (but not displayed).
+
+        We'll also show the current queue length at the end.
+        """
+        path = '/'.join(self.context.getPhysicalPath())
+        resolved_dossier_brains = self.catalog.unrestrictedSearchResults(
+            path=path,
+            is_subdossier=False,
+            sort_on='path',
+            object_provides=IDossierMarker.__identifier__,
+            review_state='dossier-state-resolved',
+            after_resolve_jobs_pending=False)
+
+        all_dossier_stats = OrderedDict()
+        missing_by_dossier = []
+
+        for brain in resolved_dossier_brains:
+            dossier = brain.getObject()
+
+            dossier_stats, docs_missing_archival_file = self._check_dossier(dossier)
+            dossier_path = brain.getPath()
+            all_dossier_stats[dossier_path] = dossier_stats
+
+            if docs_missing_archival_file:
+                missing_by_dossier.append({
+                    'dossier': dossier,
+                    'missing': docs_missing_archival_file})
+
+        self.all_dossier_stats = all_dossier_stats
+
+        # Display (and log) summary report
+        self.log("Archival file report")
+        self.log(78 * "=")
+        self.log("")
+
+        result = self.render_result_tables()
+        for line in result.splitlines():
+            self.log(line)
+
+        # Log individual documents that are missing archival file (per dossier)
+        self.log_to_file("")
+        self.log_to_file("List of documents missing archival file")
+        self.log_to_file("=" * 80)
+        self.log_to_file("")
+
+        for group in missing_by_dossier:
+            dossier = group['dossier']
+            docs = group['missing']
+            self.log_to_file(repr(dossier))
+            for doc in docs:
+                self.log_to_file("  %r" % doc)
+            self.log_to_file("")
+
+        # Display current queue length, just to be helpful
+        assert IPloneSiteRoot.providedBy(self.context)
+        ann = IAnnotations(self.context)
+        queue = ann.get(MISSING_ARCHIVAL_FILE_KEY, {})
+
+        queued_dossiers = len(queue)
+        queued_docs = sum(map(len, queue.values()))
+
+        self.log("")
+        self.log("Current queue length")
+        self.log("=" * 80)
+        self.log("%s documents queued (from %s dossiers)" % (
+            queued_docs, queued_dossiers))
+
+        return missing_by_dossier
+
+    def _check_dossier(self, dossier):
+        """Check an individual dossier's documents for missing archival file.
+
+        First, we determine if a document in question actually *should* have
+        an archival file. If it should, but doesn't, it's tracked as 'missing'.
+        """
+        dossier_stats = Counter()
+        dossier_stats['states'] = Counter()
+        dossier_path = '/'.join(dossier.getPhysicalPath())
+
+        contained_docs = self.catalog.unrestrictedSearchResults(
+            path={'query': dossier_path},
+            object_provides=IBaseDocument.__identifier__,
+        )
+        dossier_stats['total_docs_in_dossier'] = len(contained_docs)
+
+        docs_missing_archival_file = []
+        for doc_brain in contained_docs:
+            doc = doc_brain.getObject()
+
+            # Determine if this document should have an archival file
+            should_have_archival_file = self.should_have_archival_file(doc)
+
+            if should_have_archival_file:
+                dossier_stats['should_have_archival_file'] += 1
+
+            # Check if an archival file is present
+            if getattr(doc, 'archival_file', None) is not None:
+                dossier_stats['with'] += 1
+            else:
+                dossier_stats['without'] += 1
+
+                if should_have_archival_file:
+                    dossier_stats['missing'] += 1
+                    docs_missing_archival_file.append(doc)
+
+        return dossier_stats, docs_missing_archival_file
+
+    def should_have_archival_file(self, doc):
+        """Determine whether an IBaseDocument should have an archival file.
+        """
+        if doc.is_mail:
+            return False
+
+        if doc.title.startswith(u'Dossier Journal '):
+            return False
+
+        bdoc = IBumblebeeDocument(doc)
+        if not bdoc.is_convertable():
+            return False
+
+        return True
+
+    def render_result_tables(self):
+        """Return a multiline string representation of the result tables.
+        """
+        all_dossier_stats = self.all_dossier_stats
+        assert all_dossier_stats is not None
+
+        totals = Counter()
+
+        dossier_table = TextTable()
+        dossier_table.add_row((
+            'path',
+            'total_docs_in_dossier',
+            'should_have_archival_file',
+            'with',
+            'without',
+            'missing',
+        ))
+
+        totals['total_resolved_dossiers'] = len(all_dossier_stats)
+
+        for dossier_path, dossier_stats in all_dossier_stats.items():
+            dossier_table.add_row((
+                dossier_path,
+                dossier_stats['total_docs_in_dossier'],
+                dossier_stats['should_have_archival_file'],
+                dossier_stats['with'],
+                dossier_stats['without'],
+                dossier_stats['missing'],
+            ))
+
+            totals['total_docs'] += dossier_stats['total_docs_in_dossier']
+            totals['total_should_have_archival_file'] += dossier_stats['should_have_archival_file']
+            totals['total_missing'] += dossier_stats['missing']
+
+        output = ''
+        output += dossier_table.generate_output()
+        output += '\n\n'
+
+        totals_table = TextTable()
+        totals_table.add_row((
+            'total_resolved_dossiers',
+            'total_docs',
+            'total_should_have_archival_file',
+            'total_missing',
+        ))
+        totals_table.add_row((
+            totals['total_resolved_dossiers'],
+            totals['total_docs'],
+            totals['total_should_have_archival_file'],
+            totals['total_missing'],
+        ))
+
+        output += totals_table.generate_output()
+
+        return output
+
+    def queue_missing(self, missing_by_dossier):
+        """Queue conversion job for documents missing their archival file.
+
+        This method takes a list of dicts, one per dossier that contains at
+        least one document with a missing archival file.
+        """
+        self.log("")
+        self.log("Queueing missing archival files")
+        self.log("=" * 80)
+
+        total_missing = sum([len(group['missing']) for group in missing_by_dossier])
+
+        self.log("Queueing archival file conversion for %s total documents" % total_missing)
+
+        assert IPloneSiteRoot.providedBy(self.context)
+        ann = IAnnotations(self.context)
+        if MISSING_ARCHIVAL_FILE_KEY not in ann:
+            ann[MISSING_ARCHIVAL_FILE_KEY] = IOBTree()
+        queue = ann[MISSING_ARCHIVAL_FILE_KEY]
+
+        for group in missing_by_dossier:
+            dossier = group['dossier']
+            missing = group['missing']
+            self.log("  Queueing %s documents for %r" % (len(missing), dossier))
+
+            intids = getUtility(IIntIds)
+            dossier_intid = intids.getId(dossier)
+
+            if dossier_intid in queue:
+                self.log('  (Replacing already queued documents for %r)' % dossier)
+
+            queue[dossier_intid] = IITreeSet()
+            for doc in missing:
+                intid = intids.getId(doc)
+                queue[dossier_intid].add(intid)
+                self.log("    Queued: IntId %s (%r)" % (intid, doc))
+
+        self.log("Done. Queued %s documents for conversion" % total_missing)
+
+
+class Logger(LogFilePathFinder):
+    """Quick & dirty logging facility that allows us to display and log
+    messages at the same time, but also exclusively log to the file for
+    details that would clutter the console output.
+    """
+
+    def __init__(self, filename_basis):
+        super(Logger, self).__init__()
+        self.logfile_path = self.get_logfile_path(filename_basis)
+
+    def __enter__(self):
+        self.logfile = open(self.logfile_path, 'w')
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.logfile.close()
+
+    def log(self, line):
+        if not line.endswith('\n'):
+            line += '\n'
+        sys.stdout.write(line)
+        self.log_to_file(line)
+
+    def log_to_file(self, line):
+        if not line.endswith('\n'):
+            line += '\n'
+        self.logfile.write(line)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('cmd', choices=['report_missing', 'queue_missing'],
+                        help='Command')
+    parser.add_argument('-s', dest='site_root', default=None,
+                        help='Absolute path to the Plone site')
+    parser.add_argument('-n', dest='dryrun', default=False, help='Dryrun')
+
+    options = parser.parse_args(sys.argv[3:])
+
+    # report_missing should always be readonly
+    if options.cmd == 'report_missing':
+        options.dryrun = True
+
+    app = setup_app()
+    portal = setup_plone(app, options)
+
+    with Logger('archival-file-checker') as logger:
+        if options.dryrun:
+            transaction.doom()
+
+        checker = ArchivalFileChecker(portal, options, logger)
+        checker.run()
+
+        if not options.dryrun:
+            transaction.commit()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This PR adds a script that produces
- a **report of documents missing their archival file**
- optionally **queues them for conversion**

and 
- a nightly job provider that **triggers conversion for those queued documents**.

> **Usage**: archival_file_checker.py [-n] [report_missing | queue_missing]
>
> The script takes one of two commmands:
>
> `report_missing`
>     Reports all documents missing their archival file.
>
> `queue_missing`
>     Reports the documents, and additionally queues them for conversion by
>     a nightly job (by adding them to a persistent queue on the site root).
>
> The script will display some basic console output, and automatically log
> that ouput and some more detailed information to a logfile.

### Identifying documents missing their archival file 

Identifying the documents that should have an archival file, but don't, is done as follows:
For all **candidate dossiers**, check if the documents contained in them are missing their archival file.

A candidate dossier is any dossier that:
- is resolved
- doesn't have any after-resolve jobs pending
- isn't a subdossier (we'll check docs recursively)

For each document in those dossiers we then determine if it acutally _needs_ an archival file. `IBaseDocument`s that don't are:
- Mails
- Dossier Journal PDFs
- Documents that aren't Bumblebee-convertable

If the document should have an archival file but doesn't, it's flagged as `missing`.

For each dossier we'll gather some stats that allow us to cross-check that the script is operating correctly, even though in the end we only really need a list of documents (per dossier) that are missing their archival file.

Once done, we'll display (and log) a summary report. In addition, a detailed list of the documents missing their archival file is logged to the file (but not displayed).

We'll also show the current queue length at the end.

### Queueing documents for conversion of their missing archival file

The documents for which we'll want to trigger conversion are written to a persistent queue when the script is invoked with the `queue_missing` command. This queue is an IOBTree on the site root annotations - a mapping from a dossier's IntId to a list of document IntIds in that dossier that need conversion.

It is grouped by dossier because this allows us to process the queue in more reasonably sized chunks, instead of every single document being considered a "job" (which would lead to a commit every time).

So the unit of work for the nightly job is a dossier, and during the execution of that job it will trigger the conversion for that dossier's missing archival files.

### Nightly job to convert documents from the queue

A nightly job will then present the dossier IntIds (the keys in the queue) to the runner as it's list of jobs, and, when invoked with such a dossier IntId, trigger the conversion of the document IntIds that are listed in the queue under that dossier IntId.

The nightly job includes two measures to try to not overload Bumblebee too much, and possibly displace other, more important conversion jobs (nightly dossier resolution, or preview PDFs during the day):
- Each conversion is followed by a `time.sleep(1)` to at least stagger the conversion requests a little bit
- There is a `MAX_CONVERSION_REQUESTS_PER_NIGHT` (currently 1000). Once that many conversion requests have been queued by the archival file job during one nightly run, it will cease its work and further processing of the queue will resume the following night. 