### PR TITLE
Nightly archival file job: Bump max conversion request to 2000.

### DIFF
--- a/opengever/maintenance/nightly_archival_file_job.py
+++ b/opengever/maintenance/nightly_archival_file_job.py
@@ -22,7 +22,7 @@ except ImportError:
 
 
 MISSING_ARCHIVAL_FILE_KEY = 'DOCS_WITH_MISSING_ARCHIVAL_FILE'
-MAX_CONVERSION_REQUESTS_PER_NIGHT = 1000
+MAX_CONVERSION_REQUESTS_PER_NIGHT = 2000
 
 # Track total number of conversion requests sent per nightly run
 sent_conversion_requests = 0


### PR DESCRIPTION
Based on experiences from production, Bumblebee can convert up to 1 doc/s. We therefore increase the nightly limit for now.