### PR TITLE
Handle customer specific behavior fields in the persist_default values scripts.

### DIFF
--- a/opengever/maintenance/scripts/fix_non_persisted_values.py
+++ b/opengever/maintenance/scripts/fix_non_persisted_values.py
@@ -254,6 +254,10 @@ OPTIONAL_WITHOUT_DEFAULT = {
         'private_city',  # Textline - mv=None
         'comment',  # Text - mv=None
     ],
+    'IRRProtocolBehavior': [
+        'keywordGovernmentMinutes',  # Choice - mv=None
+    ],
+
 }
 
 

--- a/opengever/maintenance/scripts/fix_non_persisted_values.py
+++ b/opengever/maintenance/scripts/fix_non_persisted_values.py
@@ -257,6 +257,9 @@ OPTIONAL_WITHOUT_DEFAULT = {
     'IRRProtocolBehavior': [
         'keywordGovernmentMinutes',  # Choice - mv=None
     ],
+    'IGDGEACaseBehavior': [
+        'department',  # Choice - mv=None
+    ],
 
 }
 

--- a/opengever/maintenance/scripts/fix_non_persisted_values.py
+++ b/opengever/maintenance/scripts/fix_non_persisted_values.py
@@ -216,6 +216,25 @@ OPTIONAL_WITHOUT_DEFAULT = {
     'IDispositionSchema': [
         'transfer_number',  # TextLine - mv=None
     ],
+    'IARPCaseBehavior2': [
+        'applicant',  # Choice - mv=None
+        'location',   # Textline - mv=None
+        'requestType',   # Choice - mv=None
+        'usage',   # Choice - mv=None
+        'coordinateX',   # Int - mv=None
+        'coordinateY',   # Int - mv=None
+        'areaNew',   # Choice - mv=None
+        'volumeNew',   # Choice - mv=None
+        'volumeNew',   # Choice - mv=None
+        'agent',  # List - mv=None
+        'community',  # List - mv=None
+        'assekNumber',  # List - mv=None
+        'zones',   # List - mv=None
+        'approval',  # Bool - mv=None
+        'conditionDmPf',  # Bool - mv=None
+        'conditionEnvironment',  # Bool - mv=None
+        'legalTitle',  # list - mv=None
+    ],
 }
 
 

--- a/opengever/maintenance/scripts/fix_non_persisted_values.py
+++ b/opengever/maintenance/scripts/fix_non_persisted_values.py
@@ -274,6 +274,10 @@ OPTIONAL_WITHOUT_DEFAULT = {
         'vgPlaintNumber',  # Textline - mv=None
         'bgPlaintNumber',  # Textline - mv=None
     ],
+    'IDIADACaseBehavior': [
+        'karcEventIdentifier',  # Textline - mv=None
+        'dmpfObjectIdentifier',  # Textline - mv=None
+    ],
 }
 
 

--- a/opengever/maintenance/scripts/fix_non_persisted_values.py
+++ b/opengever/maintenance/scripts/fix_non_persisted_values.py
@@ -235,6 +235,25 @@ OPTIONAL_WITHOUT_DEFAULT = {
         'conditionEnvironment',  # Bool - mv=None
         'legalTitle',  # list - mv=None
     ],
+    'ISKAKRCaseBehavior': [
+        'tablingNumber',  # Textline - mv=None
+        'presidentOfComission',   # Choice (Textline) - mv=None
+        'appropriate',   # List - mv=None
+        'firstReading',   # Date - mv=None
+        'secondReading',   # Date - mv=None
+    ],
+    'IKRContactAddition': [
+        'community',  # Choice - mv=None
+        'parties',  # Choice - mv=None
+        'entry',  # Date - mv=None
+        'job',  # Tuple - mv=None
+        'hometown',  # Tuple - mv=None
+        'private_address',  # Textline - mv=None
+        'private_zipcode',  # Textline - mv=None
+        'private_city',  # Textline - mv=None
+        'private_city',  # Textline - mv=None
+        'comment',  # Text - mv=None
+    ],
 }
 
 

--- a/opengever/maintenance/scripts/fix_non_persisted_values.py
+++ b/opengever/maintenance/scripts/fix_non_persisted_values.py
@@ -260,7 +260,20 @@ OPTIONAL_WITHOUT_DEFAULT = {
     'IGDGEACaseBehavior': [
         'department',  # Choice - mv=None
     ],
-
+    'IBDBDSBaseBehavior': [
+        'bd_department',  # Choice - mv=None
+    ],
+    'IBDBDSCaseBehavior2': [
+        'commune',  # List - mv=None
+        'gsNumber',  # Text - mv=None
+    ],
+    'IBDBDSCaseBDBehavior': [
+        'bdPlaintNumber',  # Textline - mv=None
+    ],
+    'IBDBDSCaseVGBGBehavior': [
+        'vgPlaintNumber',  # Textline - mv=None
+        'bgPlaintNumber',  # Textline - mv=None
+    ],
 }
 
 


### PR DESCRIPTION
I've checked all the added fields, they're not required and does not have any default value.

Used for https://github.com/4teamwork/opengever.zug/issues/324