### PR TITLE
Raise CONVERSION_REQUESTS_PER_NIGHT limit for conversion job.

### DIFF
--- a/opengever/maintenance/nightly_archival_file_job.py
+++ b/opengever/maintenance/nightly_archival_file_job.py
@@ -22,7 +22,7 @@ except ImportError:
 
 
 MISSING_ARCHIVAL_FILE_KEY = 'DOCS_WITH_MISSING_ARCHIVAL_FILE'
-MAX_CONVERSION_REQUESTS_PER_NIGHT = 2000
+MAX_CONVERSION_REQUESTS_PER_NIGHT = 10000
 
 # Track total number of conversion requests sent per nightly run
 sent_conversion_requests = 0


### PR DESCRIPTION
The first runs has shown that we can handle 10'000 docs in the given time window.