### PR TITLE
Testing: Drop unittest2

### DIFF
--- a/opengever/maintenance/tests/test_grokking.py
+++ b/opengever/maintenance/tests/test_grokking.py
@@ -1,8 +1,8 @@
 from opengever.maintenance.testing import OG_MAINTENANCE_INTEGRATION
-import unittest2
+import unittest
 
 
-class TestZCML(unittest2.TestCase):
+class TestZCML(unittest.TestCase):
 
     layer = OG_MAINTENANCE_INTEGRATION
 

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ import os
 version = '1.0.dev0'
 
 tests_require = [
+    'ftw.bumblebee[tests]',
     'ftw.testing',
     'plone.app.testing',
     'plone.testing',


### PR DESCRIPTION
Fixes test failures.

Because `opengever.maintenance` indirectly relies on some of `ftw.bumblebee`'s testing layers, we also need to pull in `ftw.bumblebee[tests]` as a testing dependency.