### PR TITLE
Only include .monitor package if ftw.monitor is not installed.

### DIFF
--- a/opengever/maintenance/configure.zcml
+++ b/opengever/maintenance/configure.zcml
@@ -14,7 +14,9 @@
     <includeDependencies package="." />
 
     <include package=".browser" />
-    <include package=".monitor" />
+    <configure zcml:condition="not-installed ftw.monitor">
+      <include package=".monitor" />
+    </configure>
 
   <adapter
       factory=".nightly_archival_file_job.NightlyArchivalFileConversion"


### PR DESCRIPTION
Make the import of the `.monitor` subpackage inside `opengever.maintenance` conditional.

If `ftw.monitor` is installed, we don't want to start a monitor server from `opengever.maintenance` the "legacy way".
