### PR TITLE
Add test buildout for the 2019.4.x releases.

### DIFF
--- a/test-og-2019.4.x.cfg
+++ b/test-og-2019.4.x.cfg
@@ -1,5 +1,5 @@
 [buildout]
 extends =
     https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
-    https://raw.githubusercontent.com/4teamwork/opengever.core/2019.4.0/versions.cfg
+    https://raw.githubusercontent.com/4teamwork/opengever.core/2019.4.1/versions.cfg
     base-testing.cfg

--- a/test-og-2019.4.x.cfg
+++ b/test-og-2019.4.x.cfg
@@ -1,0 +1,5 @@
+[buildout]
+extends =
+    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
+    https://raw.githubusercontent.com/4teamwork/opengever.core/2019.4.0/versions.cfg
+    base-testing.cfg


### PR DESCRIPTION
New release 2019.4.0 has been shipped.