### PR TITLE
Add script to show 'preserved_as_paper_default' value.

### DIFF
--- a/opengever/maintenance/scripts/show_preserved_as_paper_default.py
+++ b/opengever/maintenance/scripts/show_preserved_as_paper_default.py
@@ -1,0 +1,28 @@
+"""
+Show default for 'preserved_as_paper_default'
+
+    bin/instance run show_preserved_as_paper_default.py
+
+"""
+from opengever.document.interfaces import IDocumentSettings
+from opengever.maintenance.debughelpers import setup_app
+from opengever.maintenance.debughelpers import setup_option_parser
+from opengever.maintenance.debughelpers import setup_plone
+from plone import api
+
+
+def show_preserved_as_paper_default(plone):
+    value = api.portal.get_registry_record(
+        'preserved_as_paper_default', interface=IDocumentSettings)
+    print "client: %s | preserved_as_paper_default: %r" % (plone.id, value)
+
+
+if __name__ == '__main__':
+    app = setup_app()
+
+    parser = setup_option_parser()
+    (options, args) = parser.parse_args()
+
+    plone = setup_plone(app, options)
+
+    show_preserved_as_paper_default(plone)


### PR DESCRIPTION
Simple script that dumps the corresponding registry value.

Is already running like that in production, I'm just checking it in here in case we need to do it another time.