### PR TITLE
Add option to index bumblebee checksums

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 1.0 (unreleased)
 ----------------
 
+- Add option to index bumblebee checksums. [buchi]
+
 - Add script to export the dossier structure of a repofolder to an excel file. [njohner]
 
 - Make import of five.z2monitor conditional. [njohner]


### PR DESCRIPTION
This option is meant to be used after a bundle import to calculate and
reindex bumblebee checksums. Unlike reindex it only processes documents
where the checksum is missing.

During reindex collective.indexing is disabled to avoid postponing
the work to the commit phase.

Requires https://github.com/4teamwork/ftw.bumblebee/pull/132