### PR TITLE
Bump tests for 2020.2.x to 2020.2.6.

### DIFF
--- a/test-og-2020.2.x.cfg
+++ b/test-og-2020.2.x.cfg
@@ -1,5 +1,5 @@
 [buildout]
 extends =
     https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
-    https://raw.githubusercontent.com/4teamwork/opengever.core/2020.2.4/versions.cfg
+    https://raw.githubusercontent.com/4teamwork/opengever.core/2020.2.6/versions.cfg
     base-testing.cfg

--- a/test-og-develop.cfg
+++ b/test-og-develop.cfg
@@ -11,3 +11,8 @@ auto-checkout -=
 
 auto-checkout +=
     opengever.core
+
+[test]
+# this can be removed when we update to ftw.keywordwidget > 2.1.2
+eggs +=
+    unittest2


### PR DESCRIPTION
Unfortunately i had to temporarily make sure that `unittest2` is included for tests against current master. It seems that it was removed from most packages as a dependency, that's why it is no longer required. Unfortunately `ftw.keywordwidget` needs it, but we do not include `ftw.keywordwidget[test]` dependencies. I propose to add this simple workaround until we upgrade `ftw.keywordwidget` to a newer version.