### PR TITLE
Drop testing against versions smaller than 2019.1.

### DIFF
--- a/test-og-2017.6.x.cfg
+++ b/test-og-2017.6.x.cfg
@@ -1,5 +1,0 @@
-[buildout]
-extends =
-    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
-    https://raw.githubusercontent.com/4teamwork/opengever.core/2017.6.8/versions.cfg
-    base-testing.cfg

--- a/test-og-2017.7.x.cfg
+++ b/test-og-2017.7.x.cfg
@@ -1,5 +1,0 @@
-[buildout]
-extends =
-    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
-    https://raw.githubusercontent.com/4teamwork/opengever.core/2017.7.8/versions.cfg
-    base-testing.cfg

--- a/test-og-2018.1.x.cfg
+++ b/test-og-2018.1.x.cfg
@@ -1,5 +1,0 @@
-[buildout]
-extends =
-    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
-    https://raw.githubusercontent.com/4teamwork/opengever.core/2018.1.5/versions.cfg
-    base-testing.cfg

--- a/test-og-2018.2.x.cfg
+++ b/test-og-2018.2.x.cfg
@@ -1,5 +1,0 @@
-[buildout]
-extends =
-    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
-    https://raw.githubusercontent.com/4teamwork/opengever.core/2018.2.5/versions.cfg
-    base-testing.cfg

--- a/test-og-2018.3.x.cfg
+++ b/test-og-2018.3.x.cfg
@@ -1,5 +1,0 @@
-[buildout]
-extends =
-    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
-    https://raw.githubusercontent.com/4teamwork/opengever.core/2018.3.7/versions.cfg
-    base-testing.cfg

--- a/test-og-2018.4.x.cfg
+++ b/test-og-2018.4.x.cfg
@@ -1,5 +1,0 @@
-[buildout]
-extends =
-    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
-    https://raw.githubusercontent.com/4teamwork/opengever.core/2018.4.8/versions.cfg
-    base-testing.cfg

--- a/test-og-2018.5.x.cfg
+++ b/test-og-2018.5.x.cfg
@@ -1,5 +1,0 @@
-[buildout]
-extends =
-    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
-    https://raw.githubusercontent.com/4teamwork/opengever.core/2018.5.7/versions.cfg
-    base-testing.cfg


### PR DESCRIPTION
Older versions than `2019.1` are no longer in use productively with any customer.

The only one i found in https://matrix.4teamwork.ch/deployments?utf8=%E2%9C%93&deployment_filter%5Bname%5D=&deployment_filter%5Bmaintainer_id%5D=&deployment_filter%5Bkitt_id%5D=&deployment_filter%5Bdependencies_attributes%5D%5B0%5D%5Bname%5D=opengever.core&deployment_filter%5Bdependencies_attributes%5D%5B0%5D%5Bversion%5D=&deployment_filter%5Bdependencies_attributes%5D%5B0%5D%5Bnot%5D=0&deployment_filter%5Brepository_url%5D=&deployment_filter%5Bstatus%5D=installed&deployment_filter%5Bdirty%5D=0&deployment_filter%5Bmissing_patches%5D=0&deployment_filter%5Bneeds_rotation%5D=0&deployment_filter%5Bunpacked_zodbs%5D=0&deployment_filter%5Bregex%5D=0&deployment_filter%5Brunning%5D=0&deployment_filter%5Bstopped%5D=0&deployment_filter%5Bstale%5D=0&deployment_filter%5Bfrom_src%5D=0 seems to be a rogue agent reporting incorrectly.

We could probably drop more aggressively but some deployments still seem to exist for each `2019.x.` version, although they strike me as abandoned things we might want to cleanup eventually.