### PR TITLE
Add script to reindex is_subtask in solr.

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -25,7 +25,10 @@ import tempfile
 
 from optparse import OptionParser
 
-tmpeggs = tempfile.mkdtemp()
+__version__ = '2015-07-01'
+# See zc.buildout's changelog if this version is up to date.
+
+tmpeggs = tempfile.mkdtemp(prefix='bootstrap-')
 
 usage = '''\
 [DESIRED PYTHON FOR BUILDOUT] bootstrap.py [options]
@@ -35,13 +38,14 @@ Bootstraps a buildout-based project.
 Simply run this script in a directory containing a buildout.cfg, using the
 Python that you want bin/buildout to use.
 
-Note that by using --find-links to point to local resources, you can keep 
+Note that by using --find-links to point to local resources, you can keep
 this script from going over the network.
 '''
 
 parser = OptionParser(usage=usage)
-parser.add_option("-v", "--version", help="use a specific zc.buildout version")
-
+parser.add_option("--version",
+                  action="store_true", default=False,
+                  help=("Return bootstrap.py version."))
 parser.add_option("-t", "--accept-buildout-test-releases",
                   dest='accept_buildout_test_releases',
                   action="store_true", default=False,
@@ -59,36 +63,57 @@ parser.add_option("-f", "--find-links",
 parser.add_option("--allow-site-packages",
                   action="store_true", default=False,
                   help=("Let bootstrap.py use existing site packages"))
-
+parser.add_option("--buildout-version",
+                  help="Use a specific zc.buildout version")
+parser.add_option("--setuptools-version",
+                  help="Use a specific setuptools version")
+parser.add_option("--setuptools-to-dir",
+                  help=("Allow for re-use of existing directory of "
+                        "setuptools versions"))
 
 options, args = parser.parse_args()
+if options.version:
+    print("bootstrap.py version %s" % __version__)
+    sys.exit(0)
+
 
 ######################################################################
 # load/install setuptools
 
 try:
-    if options.allow_site_packages:
-        import setuptools
-        import pkg_resources
     from urllib.request import urlopen
 except ImportError:
     from urllib2 import urlopen
 
 ez = {}
-exec(urlopen('https://bootstrap.pypa.io/ez_setup.py').read(), ez)
+if os.path.exists('ez_setup.py'):
+    exec(open('ez_setup.py').read(), ez)
+else:
+    exec(urlopen('https://bootstrap.pypa.io/ez_setup.py').read(), ez)
 
 if not options.allow_site_packages:
     # ez_setup imports site, which adds site packages
-    # this will remove them from the path to ensure that incompatible versions 
+    # this will remove them from the path to ensure that incompatible versions
     # of setuptools are not in the path
     import site
-    # inside a virtualenv, there is no 'getsitepackages'. 
+    # inside a virtualenv, there is no 'getsitepackages'.
     # We can't remove these reliably
     if hasattr(site, 'getsitepackages'):
         for sitepackage_path in site.getsitepackages():
-            sys.path[:] = [x for x in sys.path if sitepackage_path not in x]
+            # Strip all site-packages directories from sys.path that
+            # are not sys.prefix; this is because on Windows
+            # sys.prefix is a site-package directory.
+            if sitepackage_path != sys.prefix:
+                sys.path[:] = [x for x in sys.path
+                               if sitepackage_path not in x]
 
 setup_args = dict(to_dir=tmpeggs, download_delay=0)
+
+if options.setuptools_version is not None:
+    setup_args['version'] = options.setuptools_version
+if options.setuptools_to_dir is not None:
+    setup_args['to_dir'] = options.setuptools_to_dir
+
 ez['use_setuptools'](**setup_args)
 import setuptools
 import pkg_resources
@@ -104,7 +129,12 @@ for path in sys.path:
 
 ws = pkg_resources.working_set
 
+setuptools_path = ws.find(
+    pkg_resources.Requirement.parse('setuptools')).location
+
+# Fix sys.path here as easy_install.pth added before PYTHONPATH
 cmd = [sys.executable, '-c',
+       'import sys; sys.path[0:0] = [%r]; ' % setuptools_path +
        'from setuptools.command.easy_install import main; main()',
        '-mZqNxd', tmpeggs]
 
@@ -117,21 +147,23 @@ find_links = os.environ.get(
 if find_links:
     cmd.extend(['-f', find_links])
 
-setuptools_path = ws.find(
-    pkg_resources.Requirement.parse('setuptools')).location
-
 requirement = 'zc.buildout'
-version = options.version
+version = options.buildout_version
 if version is None and not options.accept_buildout_test_releases:
     # Figure out the most recent final version of zc.buildout.
     import setuptools.package_index
     _final_parts = '*final-', '*final'
 
     def _final_version(parsed_version):
-        for part in parsed_version:
-            if (part[:1] == '*') and (part not in _final_parts):
-                return False
-        return True
+        try:
+            return not parsed_version.is_prerelease
+        except AttributeError:
+            # Older setuptools
+            for part in parsed_version:
+                if (part[:1] == '*') and (part not in _final_parts):
+                    return False
+            return True
+
     index = setuptools.package_index.PackageIndex(
         search_path=[setuptools_path])
     if find_links:
@@ -156,7 +188,7 @@ if version:
 cmd.append(requirement)
 
 import subprocess
-if subprocess.call(cmd, env=dict(os.environ, PYTHONPATH=setuptools_path)) != 0:
+if subprocess.call(cmd) != 0:
     raise Exception(
         "Failed to execute command:\n%s" % repr(cmd)[1:-1])
 

--- a/opengever/maintenance/scripts/reindex_is_subtask_in_solr.py
+++ b/opengever/maintenance/scripts/reindex_is_subtask_in_solr.py
@@ -1,0 +1,66 @@
+"""
+Reindexes 'is_subtask' in Solr for all objects that are missing it.
+
+    bin/instance run reindex_is_subtask_in_solr.py
+
+"""
+from ftw.solr.interfaces import ISolrConnectionManager
+from ftw.solr.interfaces import ISolrIndexHandler
+from ftw.solr.interfaces import ISolrSearch
+from opengever.base.solr import OGSolrContentListingObject
+from opengever.base.solr import OGSolrDocument
+from opengever.maintenance.debughelpers import setup_app
+from opengever.maintenance.debughelpers import setup_option_parser
+from opengever.maintenance.debughelpers import setup_plone
+from zope.component import getMultiAdapter
+from zope.component import getUtility
+
+
+BATCH_SIZE = 1000
+HARD_LIMIT = 1000000
+
+
+def reindex_path_depth(plone):
+    solr = getUtility(ISolrSearch)
+    manager = getUtility(ISolrConnectionManager)
+
+    i = 0
+
+    while True and i < HARD_LIMIT:
+        query = dict(
+            query=u'object_provides:opengever.task.task.ITask -is_subtask:[0 TO 1]',
+            rows=BATCH_SIZE,
+        )
+
+        results = solr.search(**query)
+        if len(results.docs) == 0:
+            break
+
+        remaining = results.num_found
+        for solr_doc in results.docs:
+            clobj = OGSolrContentListingObject(OGSolrDocument(solr_doc))
+            obj = clobj.getObject()
+
+            if obj is None:
+                continue
+
+            print "Reindexing is_subtask for %r" % obj
+            handler = getMultiAdapter((obj, manager), ISolrIndexHandler)
+            handler.add(['is_subtask'])
+            i += 1
+
+        print "Intermediate commit (done %s, remaining %s)" % (i, remaining)
+        manager.connection.commit(soft_commit=False, extract_after_commit=False)
+
+    manager.connection.commit(soft_commit=False, extract_after_commit=False)
+
+
+if __name__ == '__main__':
+    app = setup_app()
+
+    parser = setup_option_parser()
+    (options, args) = parser.parse_args()
+
+    plone = setup_plone(app, options)
+
+    reindex_path_depth(plone)


### PR DESCRIPTION
It seems that we've had issues during the update from solr 7 to solr 8 for Köniz. This led to fields that were introduced / updated in solr during that update to end up not being updated. It seems that two fields were concerned, `path_depth` and `is_subtask`. `path_depth` was already fixed in https://github.com/4teamwork/opengever.maintenance/pull/225, here we add a similar script to index `is_subtask` where necessary. 

The corresponding upgrade step was https://github.com/4teamwork/opengever.core/blob/master/opengever/core/upgrades/20190827180126_replace_is_subtask_field_index_with_a_boolean_index/upgrade.py

I also update `bootstrap.py` and fix the batching in the script introduced for `path_depth`

For https://4teamwork.atlassian.net/browse/CA-1112