### PR TITLE
Migrate external reference for workspaces

### DIFF
--- a/opengever/maintenance/scripts/mark_dossiers_linked_with_workspaces_and_dump_links.py
+++ b/opengever/maintenance/scripts/mark_dossiers_linked_with_workspaces_and_dump_links.py
@@ -1,0 +1,61 @@
+"""bin/instance run ./scripts/mark_dossiers_linked_with_workspaces_and_dump_links.py
+"""
+
+from opengever.base.oguid import Oguid
+from opengever.maintenance.debughelpers import setup_app
+from opengever.maintenance.debughelpers import setup_option_parser
+from opengever.maintenance.debughelpers import setup_plone
+from opengever.ogds.base.utils import get_current_admin_unit
+from opengever.workspaceclient.interfaces import ILinkedToWorkspace
+from opengever.workspaceclient.storage import LinkedWorkspacesStorage
+from plone import api
+from plone.i18n.normalizer import filenamenormalizer
+from zope.interface import alsoProvides
+import json
+import os.path
+import transaction
+
+
+def mark_dossiers_with_workspaces_and_dump_links(directory):
+    query = {'object_provides': ['opengever.dossier.behaviors.dossier.IDossierMarker'],
+             'is_subdossier': False}
+    catalog = api.portal.get_tool('portal_catalog')
+    dossier_brains = catalog.unrestrictedSearchResults(query)
+    result = {}
+    for brain in dossier_brains:
+        dossier = brain.getObject()
+        linked_workspaces = LinkedWorkspacesStorage(dossier).list()
+        if linked_workspaces:
+            dossier_oguid = Oguid.for_object(dossier).id
+            alsoProvides(dossier, ILinkedToWorkspace)
+            dossier.reindexObject(idxs=['object_provides'])
+            for linked_workspace in linked_workspaces:
+                result[linked_workspace] = dossier_oguid
+
+    print(json.dumps(result, sort_keys=True, indent=4))
+    if directory:
+        dump(directory, result)
+
+
+def dump(directory, result):
+    filename = filenamenormalizer.normalize(get_current_admin_unit().public_url) + '.json'
+    path = os.path.abspath(os.path.join(directory, filename))
+    print('Dumping to {}'.format(path))
+    with open(path, 'w+') as fio:
+        json.dump(result, fio, sort_keys=True, indent=4)
+
+
+def main():
+    app = setup_app()
+    parser = setup_option_parser()
+    parser.add_option('-d', '--dump-directory', dest='directory',
+                      help='Path to a directory where a JSON file is created with the output.')
+    (options, args) = parser.parse_args()
+    setup_plone(app, options)
+    mark_dossiers_with_workspaces_and_dump_links(options.directory)
+    transaction.commit()
+    print('Done.')
+
+
+if __name__ == '__main__':
+    main()

--- a/opengever/maintenance/scripts/set_external_reference_for_workspaces.py
+++ b/opengever/maintenance/scripts/set_external_reference_for_workspaces.py
@@ -1,0 +1,49 @@
+"""
+bin/instance run ./scripts/set_external_reference_for_workspaces.py path/to/file
+Set linked dossier oguid as external_reference for linked workspaces.
+"""
+
+from opengever.maintenance.debughelpers import setup_app
+from opengever.maintenance.debughelpers import setup_option_parser
+from opengever.maintenance.debughelpers import setup_plone
+from plone import api
+import json
+import sys
+import transaction
+
+
+def set_external_reference(file_path):
+    with open(file_path) as file_:
+        data = json.load(file_)
+    uids = data.keys()
+    query = {"object_provides": "opengever.workspace.interfaces.IWorkspace"}
+    catalog = api.portal.get_tool('portal_catalog')
+    workspace_brains = catalog.unrestrictedSearchResults(query)
+    for brain in workspace_brains:
+        workspace = brain.getObject()
+        if workspace.UID() in uids:
+            workspace.external_reference = data[workspace.UID()]
+        else:
+            workspace.external_reference = u''
+        workspace.reindexObject(idxs=['external_reference'])
+    return len(uids), len(workspace_brains)
+
+
+def main():
+    app = setup_app()
+
+    parser = setup_option_parser()
+    (options, args) = parser.parse_args()
+    if not len(args) == 1:
+        print("Missing argument, please provide a path to a JSON file")
+        sys.exit(1)
+
+    file_path = args[0]
+    setup_plone(app)
+    nof_linked_workspaces, nof_workspaces = set_external_reference(file_path)
+    transaction.commit()
+    print("Done. {} of {} workspaces are linked".format(nof_linked_workspaces, nof_workspaces))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Newly, dossiers that are linked to a workspace should be marked with an `ILinkedToWorkspace` interface. In addition, the `external_reference` field of the workspace should contain the `Oguid` of the linked dossier.

Since GEVER and Teamraum are two separate installations, the modifications cannot be migrated automatically. Therefore two migration scripts were written for this purpose.

The first script marks all linked dossiers with the interface. This is done in this script, since all dossiers have to be checked anyway to see if they are linked. Therefore it does not make sense to do this separately in an upgrade step. Also the links dossier <-> workspace are saved in a json file.

The second script reads the generated JSON file and saves the `Oguid` of the linked dossier as `external_reference` of the workspace.

On the GEVER intallation run `bin/instance run ./scripts/mark_dossiers_linked_with_workspaces_and_dump_links.py --dump-directory path/to/directory`

On the teamraum installation run `bin/instance run ./scripts/set_external_reference_for_workspaces.py path/to/file`

Relates to https://github.com/4teamwork/opengever.core/pull/6752

Jira: https://4teamwork.atlassian.net/browse/NE-100