### PR TITLE
Add script to print trashed document templates.

### DIFF
--- a/opengever/maintenance/scripts/list_trashed_document_templates.py
+++ b/opengever/maintenance/scripts/list_trashed_document_templates.py
@@ -1,0 +1,38 @@
+from opengever.maintenance.debughelpers import setup_app
+from opengever.maintenance.debughelpers import setup_option_parser
+from opengever.maintenance.debughelpers import setup_plone
+from plone import api
+
+
+def list_trashed_document_templates():
+    catalog = api.portal.get_tool("portal_catalog")
+    template_folder_paths = [
+        each.getPath() for each
+        in catalog.unrestrictedSearchResults(
+            portal_type='opengever.dossier.templatefolder')
+    ]
+    results = catalog.unrestrictedSearchResults(
+        trashed=True,
+        object_provides='opengever.document.behaviors.IBaseDocument',
+        path={'query': template_folder_paths},
+    )
+
+    print "Trashed documents: {}".format(len(results))
+    print ""
+    if results:
+        for brain in results:
+            print brain.getPath()
+        print ""
+
+
+def main():
+    parser = setup_option_parser()
+    (options, args) = parser.parse_args()
+    app = setup_app()
+    setup_plone(app)
+
+    list_trashed_document_templates()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
According to https://4teamwork.atlassian.net/wiki/spaces/4TEAM/pages/123077675/GEVER+Releases+Versions-Spezifische+Punkte we should double-check trashed document templates. We'll use the script suggested in https://github.com/4teamwork/opengever.core/pull/6793#issuecomment-757842941 but check it in so we can run it easily for all deployments.

Jira: https://4teamwork.atlassian.net/browse/CA-1298