### PR TITLE
Add option to delete trashed document templates.

### DIFF
--- a/opengever/maintenance/scripts/list_trashed_document_templates.py
+++ b/opengever/maintenance/scripts/list_trashed_document_templates.py
@@ -2,6 +2,7 @@ from opengever.maintenance.debughelpers import setup_app
 from opengever.maintenance.debughelpers import setup_option_parser
 from opengever.maintenance.debughelpers import setup_plone
 from plone import api
+import transaction
 
 
 def list_trashed_document_templates():
@@ -23,15 +24,27 @@ def list_trashed_document_templates():
         for brain in results:
             print brain.getPath()
         print ""
+    return results
+
+
+def delete_trashed_document_templates(results):
+    for brain in results:
+        obj = brain._unrestrictedGetObject()
+        api.content.delete(obj)
 
 
 def main():
     parser = setup_option_parser()
+    parser.add_option("--delete", action="store_true", dest="delete",
+                      default=False)
     (options, args) = parser.parse_args()
     app = setup_app()
     setup_plone(app)
 
-    list_trashed_document_templates()
+    results = list_trashed_document_templates()
+    if options.delete:
+        delete_trashed_document_templates(results)
+        transaction.commit()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Add a `--delete` option which allows to automatically remove all trashed templates. As discussed in https://4teamwork.atlassian.net/browse/CA-1298?focusedCommentId=21220  that's the strategy we want to use, at least for SaaS.

Jira: https://4teamwork.atlassian.net/browse/CA-1298