### PR TITLE
Improve repository migration scripts

### DIFF
--- a/opengever/maintenance/scripts/repository_migration.py
+++ b/opengever/maintenance/scripts/repository_migration.py
@@ -296,7 +296,6 @@ class ExcelDataExtractor(object):
         self.data = sheets[0]['sheet_data']
         self.n_data = len(self.data) - self.first_data_row
         self.validate_format()
-        self.is_valid = True
 
     def validate_format(self):
         headers = self.data[self.header_row]
@@ -329,6 +328,7 @@ class RepositoryExcelAnalyser(object):
         self._reference_repository_mapping = None
         self.final_positions = []
         self.catalog = api.portal.get_tool('portal_catalog')
+        self.is_valid = True
 
         # A mapping new_position_number:UID
         self.position_uid_mapping = {}

--- a/opengever/maintenance/scripts/repository_migration.py
+++ b/opengever/maintenance/scripts/repository_migration.py
@@ -1263,6 +1263,15 @@ def main():
     logger.info('\n\nwriting analysis excel...\n')
     analyser.export_to_excel()
 
+    analyser_path = os.path.join(options.output_directory, "analyser.json")
+    with open(analyser_path, "w") as outfile:
+        analyser_data = {
+            'position_guid_mapping': analyser.position_guid_mapping,
+            'position_uid_mapping': analyser.position_uid_mapping,
+            'analysed_rows': analyser.analysed_rows,
+        }
+        json.dump(analyser_data, outfile, default=vars)
+
     if not analyser.is_valid:
         logger.info('\n\nInvalid migration excel, aborting...\n')
         return
@@ -1275,6 +1284,15 @@ def main():
         logger.info('\n\nCommitting transaction...\n')
         transaction.commit()
         logger.info('Finished migration.')
+
+    migrator_path = os.path.join(options.output_directory, "migrator.json")
+    with open(migrator_path, "w") as outfile:
+        migrator_data = {
+            'operations_list': migrator.operations_list,
+            'to_reindex': migrator.to_reindex.keys(),
+            'validation_errors': migrator.validation_errors,
+        }
+        json.dump(migrator_data, outfile, default=vars)
 
     tasks_to_sync_path = os.path.join(
         options.output_directory, "tasks_to_sync.json")

--- a/opengever/maintenance/scripts/repository_migration.py
+++ b/opengever/maintenance/scripts/repository_migration.py
@@ -282,13 +282,13 @@ class ExcelDataExtractor(object):
         'new_position': Column(5, 'reference_number', u'Ordnungs-\npositions-\nnummer'),
         'new_title': Column(6, 'effective_title', u'Titel der Ordnungsposition'),
         'new_description': Column(8, 'description', u'Beschreibung (optional)'),
-        'block_inheritance': Column(19, 'block_inheritance', ''),
-        'read': Column(20, 'read_dossiers_access', ''),
-        'add': Column(21, 'add_dossiers_access', ''),
-        'edit': Column(22, 'edit_dossiers_access', ''),
-        'close': Column(23, 'close_dossiers_access', ''),
-        'reactivate': Column(24, 'reactivate_dossiers_access', ''),
-        'manage_dossiers': Column(25, 'manage_dossiers_access', ''),
+        'block_inheritance': Column(22, 'block_inheritance', ''),
+        'read': Column(23, 'read_dossiers_access', ''),
+        'add': Column(24, 'add_dossiers_access', ''),
+        'edit': Column(25, 'edit_dossiers_access', ''),
+        'close': Column(26, 'close_dossiers_access', ''),
+        'reactivate': Column(27, 'reactivate_dossiers_access', ''),
+        'manage_dossiers': Column(28, 'manage_dossiers_access', ''),
     }
 
     def __init__(self, diff_xlsx_path):

--- a/opengever/maintenance/scripts/repository_migration.py
+++ b/opengever/maintenance/scripts/repository_migration.py
@@ -326,7 +326,6 @@ class RepositoryExcelAnalyser(object):
         self.output_directory = output_directory
         self.analysed_rows = []
         self._reference_repository_mapping = None
-        self.final_positions = []
         self.catalog = api.portal.get_tool('portal_catalog')
         self.is_valid = True
 

--- a/opengever/maintenance/scripts/repository_migration.py
+++ b/opengever/maintenance/scripts/repository_migration.py
@@ -218,7 +218,7 @@ def cleanup_position(position):
     """
     if position is None:
         return None
-    position = str(position)
+    position = str(position).strip()
     if position:
         return position.replace('.', '')
 


### PR DESCRIPTION
We add the possibility to split the task syncing to a different step, as the migration itself is done on an OGDS that is not the productive one. For that we pickle the migrator object which knows which tasks will then have to be synced. This last step will be done in debug mode.

For https://4teamwork.atlassian.net/browse/CA-1267