### PR TITLE
Don't tests versions no longer used in production.

### DIFF
--- a/test-og-2019.1.x.cfg
+++ b/test-og-2019.1.x.cfg
@@ -1,5 +1,0 @@
-[buildout]
-extends =
-    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
-    https://raw.githubusercontent.com/4teamwork/opengever.core/2019.1.5/versions.cfg
-    base-testing.cfg

--- a/test-og-2019.2.x.cfg
+++ b/test-og-2019.2.x.cfg
@@ -1,5 +1,0 @@
-[buildout]
-extends =
-    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
-    https://raw.githubusercontent.com/4teamwork/opengever.core/2019.2.6/versions.cfg
-    base-testing.cfg

--- a/test-og-2019.3.x.cfg
+++ b/test-og-2019.3.x.cfg
@@ -1,5 +1,0 @@
-[buildout]
-extends =
-    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
-    https://raw.githubusercontent.com/4teamwork/opengever.core/2019.3.3/versions.cfg
-    base-testing.cfg

--- a/test-og-2019.4.x.cfg
+++ b/test-og-2019.4.x.cfg
@@ -1,5 +1,0 @@
-[buildout]
-extends =
-    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
-    https://raw.githubusercontent.com/4teamwork/opengever.core/2019.4.1/versions.cfg
-    base-testing.cfg

--- a/test-og-2020.1.x.cfg
+++ b/test-og-2020.1.x.cfg
@@ -1,5 +1,0 @@
-[buildout]
-extends =
-    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
-    https://raw.githubusercontent.com/4teamwork/opengever.core/2020.1.0/versions.cfg
-    base-testing.cfg

--- a/test-og-2020.12.x.cfg
+++ b/test-og-2020.12.x.cfg
@@ -1,9 +1,0 @@
-[buildout]
-extends =
-    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
-    https://raw.githubusercontent.com/4teamwork/opengever.core/2020.12.0/versions.cfg
-    base-testing.cfg
-
-[test]
-eggs +=
-    unittest2

--- a/test-og-2020.2.x.cfg
+++ b/test-og-2020.2.x.cfg
@@ -1,5 +1,0 @@
-[buildout]
-extends =
-    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
-    https://raw.githubusercontent.com/4teamwork/opengever.core/2020.2.6/versions.cfg
-    base-testing.cfg

--- a/test-og-2020.3.x.cfg
+++ b/test-og-2020.3.x.cfg
@@ -1,9 +1,0 @@
-[buildout]
-extends =
-    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
-    https://raw.githubusercontent.com/4teamwork/opengever.core/2020.3.1/versions.cfg
-    base-testing.cfg
-
-[test]
-eggs +=
-    unittest2

--- a/test-og-2020.4.x.cfg
+++ b/test-og-2020.4.x.cfg
@@ -1,9 +1,0 @@
-[buildout]
-extends =
-    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
-    https://raw.githubusercontent.com/4teamwork/opengever.core/2020.4.1/versions.cfg
-    base-testing.cfg
-
-[test]
-eggs +=
-    unittest2

--- a/test-og-2020.5.x.cfg
+++ b/test-og-2020.5.x.cfg
@@ -1,9 +1,0 @@
-[buildout]
-extends =
-    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
-    https://raw.githubusercontent.com/4teamwork/opengever.core/2020.5.0/versions.cfg
-    base-testing.cfg
-
-[test]
-eggs +=
-    unittest2

--- a/test-og-2020.6.x.cfg
+++ b/test-og-2020.6.x.cfg
@@ -1,9 +1,0 @@
-[buildout]
-extends =
-    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
-    https://raw.githubusercontent.com/4teamwork/opengever.core/2020.6.0/versions.cfg
-    base-testing.cfg
-
-[test]
-eggs +=
-    unittest2

--- a/test-og-2020.7.x.cfg
+++ b/test-og-2020.7.x.cfg
@@ -1,9 +1,0 @@
-[buildout]
-extends =
-    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
-    https://raw.githubusercontent.com/4teamwork/opengever.core/2020.7.0/versions.cfg
-    base-testing.cfg
-
-[test]
-eggs +=
-    unittest2

--- a/test-og-2020.8.x.cfg
+++ b/test-og-2020.8.x.cfg
@@ -1,9 +1,0 @@
-[buildout]
-extends =
-    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
-    https://raw.githubusercontent.com/4teamwork/opengever.core/2020.8.1/versions.cfg
-    base-testing.cfg
-
-[test]
-eggs +=
-    unittest2

--- a/test-og-2021.1.x.cfg
+++ b/test-og-2021.1.x.cfg
@@ -1,9 +1,0 @@
-[buildout]
-extends =
-    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
-    https://raw.githubusercontent.com/4teamwork/opengever.core/2021.1.0/versions.cfg
-    base-testing.cfg
-
-[test]
-eggs +=
-    unittest2

--- a/test-og-2021.2.x.cfg
+++ b/test-og-2021.2.x.cfg
@@ -1,9 +1,0 @@
-[buildout]
-extends =
-    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
-    https://raw.githubusercontent.com/4teamwork/opengever.core/2021.2.0/versions.cfg
-    base-testing.cfg
-
-[test]
-eggs +=
-    unittest2

--- a/test-og-2021.4.x.cfg
+++ b/test-og-2021.4.x.cfg
@@ -1,9 +1,0 @@
-[buildout]
-extends =
-    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
-    https://raw.githubusercontent.com/4teamwork/opengever.core/2021.4.2/versions.cfg
-    base-testing.cfg
-
-[test]
-eggs +=
-    unittest2

--- a/test-og-2021.6.x.cfg
+++ b/test-og-2021.6.x.cfg
@@ -1,9 +1,0 @@
-[buildout]
-extends =
-    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
-    https://raw.githubusercontent.com/4teamwork/opengever.core/2021.6.0/versions.cfg
-    base-testing.cfg
-
-[test]
-eggs +=
-    unittest2


### PR DESCRIPTION
Drop testing against versions we no longer use in production according to matrix.