### PR TITLE
Also use setuptools 44.1.1 for older versions.

### DIFF
--- a/test-og-2019.5.x.cfg
+++ b/test-og-2019.5.x.cfg
@@ -3,3 +3,7 @@ extends =
     https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
     https://raw.githubusercontent.com/4teamwork/opengever.core/2019.5.1/versions.cfg
     base-testing.cfg
+
+
+[versions]
+setuptools = 44.1.1

--- a/test-og-2019.6.x.cfg
+++ b/test-og-2019.6.x.cfg
@@ -3,3 +3,6 @@ extends =
     https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
     https://raw.githubusercontent.com/4teamwork/opengever.core/2019.6.4/versions.cfg
     base-testing.cfg
+
+[versions]
+setuptools = 44.1.1


### PR DESCRIPTION
We cannot buildout reliably with the old pinned setuptools versions, so we pin the test builds to use a newer version.

I'm expecting most 2019.X versions to go away soon in any case.

This makes sure tests against `master` are green again.