### PR TITLE
Add extended health checks (Nightly Jobs and OGDS sync).

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 1.0 (unreleased)
 ----------------
 
+- Add extended health checks (Nightly Jobs and OGDS sync). [lgraf]
+
 - Add script to cleanup notifications for ToDo activities. [njohner]
 
 - Add option to index bumblebee checksums. [buchi]

--- a/opengever/maintenance/browser/health_check.py
+++ b/opengever/maintenance/browser/health_check.py
@@ -21,6 +21,13 @@ except ImportError:
     def ogds_sync_within_24h():
         return True
 
+try:
+    from opengever.ogds.base.sync.import_stamp import get_ogds_sync_stamp
+except ImportError:
+    # opengever.core < 2021.19.0
+    def get_ogds_sync_stamp():
+        return None
+
 
 class HealthCheckView(BrowserView):
     """Health check view to be used by superlance httpok plugin and/or
@@ -53,6 +60,10 @@ class HealthCheckView(BrowserView):
             nightly_status = 'healthy' if nightly_ok else 'unhealthy'
             overall_status = 'healthy' if overall_ok else 'unhealthy'
 
+            last_ogds_sync = get_ogds_sync_stamp()
+            if last_ogds_sync:
+                last_ogds_sync = last_ogds_sync.isoformat()
+
             result = {
                 'status': overall_status,
                 'instance': {
@@ -60,6 +71,7 @@ class HealthCheckView(BrowserView):
                 },
                 'ogds': {
                     'ogds_sync_status': ogds_status,
+                    'last_ogds_sync': last_ogds_sync,
                 },
                 'nightly_jobs': {
                     'nightly_jobs_status': nightly_status,

--- a/opengever/maintenance/browser/health_check.py
+++ b/opengever/maintenance/browser/health_check.py
@@ -28,6 +28,13 @@ except ImportError:
     def get_ogds_sync_stamp():
         return None
 
+try:
+    from opengever.nightlyjobs.runner import get_nightly_run_timestamp
+except ImportError:
+    # opengever.core < 2021.19.0
+    def get_nightly_run_timestamp():
+        return None
+
 
 class HealthCheckView(BrowserView):
     """Health check view to be used by superlance httpok plugin and/or
@@ -64,6 +71,10 @@ class HealthCheckView(BrowserView):
             if last_ogds_sync:
                 last_ogds_sync = last_ogds_sync.isoformat()
 
+            last_nightly_run = get_nightly_run_timestamp()
+            if last_nightly_run:
+                last_nightly_run = last_nightly_run.isoformat()
+
             result = {
                 'status': overall_status,
                 'instance': {
@@ -75,6 +86,7 @@ class HealthCheckView(BrowserView):
                 },
                 'nightly_jobs': {
                     'nightly_jobs_status': nightly_status,
+                    'last_nightly_run': last_nightly_run,
                 },
             }
 


### PR DESCRIPTION
This uses the `nightly_run_within_24h()` and `ogds_sync_within_24h()` functions introduced in 4teamwork/opengever.core#7176 to provide an extended mode for the `@@health-check` view:

```
GET http://localhost:8080/fd/@@health-check?extended=1

{
   "status":"healthy",
   "instance":{
      "instance_status":"healthy"
   },
   "nightly_jobs":{
      "nightly_jobs_status":"healthy",
      "last_nightly_run":"2021-09-20T17:48:54.225458",
      "job_counts":{
         "maintenance-jobs":5,
         "deliver-sip-packages":0,
         "trigger-missing-archival-file-conversion":0,
         "complete-role-assignment-reports":0,
         "execute-after-resolve-jobs":0
      }
   },
   "ogds":{
      "ogds_sync_status":"healthy",
      "last_ogds_sync":"2021-09-20T17:46:38.552990"
   }
}
```
_(Whitespaced added for clarity - actual response contains all the JSON on one line)_

If any of these two are not ok, their marker strings will be `unhealthy`.

`"instance_status":"healthy"` has the same meaning as `"status": "OK" does in the non-extended version: The instance is alive, and the SQL connection works.

`status` is now an overall-status - it is only `healthy` if all three of Instance, OGDS, and Nightly Jobs are healthy. Otherwise it will be `unhealthy`.

If those helper functions can't be imported from `opengever.core` (because of an old version), they get replaced with stub functions that return `True`. This way we don't get hammered with false-positive service failures. Instead, those checks simply won't be effective yet until `opengever.core` is updated.

The jobs counts are cached (5m) because they do involve quite a few adapter lookups and BTree length checks. On my local machine, both the basic and extended `@@health-checks` took 8ms.