### PR TITLE
Drop nightly job_counts from @@health-check view

### DIFF
--- a/opengever/maintenance/browser/health_check.py
+++ b/opengever/maintenance/browser/health_check.py
@@ -1,6 +1,4 @@
-from plone.memoize import ram
 from Products.Five.browser import BrowserView
-from time import time
 import json
 
 try:
@@ -36,20 +34,6 @@ except ImportError:
     # opengever.core < 2021.19.0
     def get_nightly_run_timestamp():
         return None
-
-try:
-    from opengever.nightlyjobs.runner import get_job_counts
-except ImportError:
-    # opengever.core < 2021.19.0
-    def get_job_counts():
-        return {}
-
-
-@ram.cache(lambda *args: time() // (60 * 5))
-def get_nightly_job_counts():
-    """Get nightly job queue lengths (cached for 5min).
-    """
-    return get_job_counts()
 
 
 class HealthCheckView(BrowserView):
@@ -103,7 +87,6 @@ class HealthCheckView(BrowserView):
                 'nightly_jobs': {
                     'nightly_jobs_status': nightly_status,
                     'last_nightly_run': last_nightly_run,
-                    'job_counts': get_nightly_job_counts(),
                 },
             }
 


### PR DESCRIPTION
Drop nightly  `job_counts` from `@@health-check view`. They turned out to not be side-effect free yet, and prevent access to the
`@@health-check` view for Anonymous users.