### PR TITLE
Bump tests to 2021.23.3.

### DIFF
--- a/test-og-2021.23.x.cfg
+++ b/test-og-2021.23.x.cfg
@@ -1,7 +1,7 @@
 [buildout]
 extends =
     https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
-    https://raw.githubusercontent.com/4teamwork/opengever.core/2021.23.0/versions.cfg
+    https://raw.githubusercontent.com/4teamwork/opengever.core/2021.23.3/versions.cfg
     base-testing.cfg
 
 [test]


### PR DESCRIPTION
From 2021.23.0. Not from 2021.23.2. :(.

For [CA-2746](https://4teamwork.atlassian.net/browse/CA-2746)