### PR TITLE
Improve repository migration script

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 1.0 (unreleased)
 ----------------
 
+- Handle new argument "graceful" of task syncer in ObjectIDUpdater. [njohner]
+
 - Add extended health checks (Nightly Jobs and OGDS sync). [lgraf]
 
 - Add script to cleanup notifications for ToDo activities. [njohner]

--- a/opengever/maintenance/scripts/repository_migration.py
+++ b/opengever/maintenance/scripts/repository_migration.py
@@ -1419,10 +1419,11 @@ def main():
         return
 
     migrator = RepositoryMigrator(analyser.analysed_rows, dry_run=options.dryrun)
-    if not options.dryrun:
-        logger.info('\n\nstarting migration...\n')
-        migrator.run()
 
+    logger.info('\n\nstarting migration...\n')
+    migrator.run()
+
+    if not options.dryrun:
         logger.info('\n\nCommitting transaction...\n')
         transaction.commit()
         logger.info('Finished migration.')

--- a/opengever/maintenance/scripts/repository_migration.py
+++ b/opengever/maintenance/scripts/repository_migration.py
@@ -511,12 +511,6 @@ class RepositoryExcelAnalyser(object):
         self.catalog = api.portal.get_tool('portal_catalog')
         self.is_valid = True
 
-        # A mapping new_position_number:UID
-        self.position_uid_mapping = {}
-
-        # A mapping new_position_number:guid
-        self.position_guid_mapping = {}
-
         self.check_preconditions()
         self.prepare_guids()
         self.reporoot, self.reporoot_guid = self.get_reporoot_and_guid()
@@ -647,12 +641,6 @@ class RepositoryExcelAnalyser(object):
             self.validate_operation(operation)
 
             self.analysed_rows.append(operation)
-            if need_merge:
-                pass
-            elif not needs_creation:
-                self.position_uid_mapping[new_repo_pos.position] = operation['uid']
-            else:
-                self.position_guid_mapping[new_repo_pos.position] = new_position_guid
 
         # Make sure that analysis is invalid if any operation was invalid
         if any([not op['is_valid'] for op in self.analysed_rows]):
@@ -1492,8 +1480,7 @@ def main():
     analyser_path = os.path.join(options.output_directory, "analyser.json")
     with open(analyser_path, "w") as outfile:
         analyser_data = {
-            'position_guid_mapping': analyser.position_guid_mapping,
-            'position_uid_mapping': analyser.position_uid_mapping,
+            'position_mapping': analyser.positions_mapping,
             'analysed_rows': analyser.analysed_rows,
         }
         json.dump(analyser_data, outfile, default=vars)

--- a/opengever/maintenance/scripts/repository_migration.py
+++ b/opengever/maintenance/scripts/repository_migration.py
@@ -664,9 +664,8 @@ class RepositoryExcelAnalyser(object):
             inheritance_blocked = permissions['block_inheritance']
             if has_local_roles and not inheritance_blocked:
                 logger.warning(
-                    "\nInvalid operation: setting local roles without blocking "
+                    "\nSetting local roles without blocking "
                     "inheritance. {}\n".format(operation))
-                operation['is_valid'] = False
             elif inheritance_blocked and not has_local_roles:
                 logger.warning(
                     "\nInvalid operation: blocking inheritance without setting "

--- a/opengever/maintenance/scripts/repository_migration.py
+++ b/opengever/maintenance/scripts/repository_migration.py
@@ -618,8 +618,10 @@ class RepositoryExcelAnalyser(object):
 
             if need_number_change:
                 new_number = self.get_new_number(new_repo_pos)
-            if need_move or need_merge:
+            if need_move:
                 new_parent_guid = self.get_new_parent_guid(new_repo_pos)
+            if need_merge:
+                new_parent_guid = self.positions_mapping.get_new_pos_guid(new_repo_pos.position)
             if need_creation:
                 new_parent_guid = self.get_new_parent_guid(new_repo_pos)
                 new_position_guid = self.positions_mapping.get_new_pos_guid(new_repo_pos.position)

--- a/opengever/maintenance/scripts/repository_migration.py
+++ b/opengever/maintenance/scripts/repository_migration.py
@@ -786,34 +786,35 @@ class RepositoryExcelAnalyser(object):
         old_refnum = old_repo_pos.position
         new_refnum = new_repo_pos.position
 
-        if new_refnum and old_refnum and new_refnum != old_refnum:
-            # It's a move, merge or number change, we need to figure out which
+        if not (new_refnum and old_refnum):
+            # creation or deletion
+            return need_number_change, need_move, need_merge
 
-            # guid change is a merge operation
-            if self.positions_mapping.get_old_pos_new_guid(old_refnum):
-                need_merge = True
-                return need_number_change, need_move, need_merge
+        # guid change is a merge operation
+        if self.positions_mapping.get_old_pos_new_guid(old_refnum):
+            need_merge = True
+            return need_number_change, need_move, need_merge
 
-            # move operation is when parent changes except if the parent is
-            # merged into the new parent
-            old_parent_pos_guid = self.positions_mapping.get_old_pos_guid(old_repo_pos.parent_position)
-            new_parent_pos_guid = self.positions_mapping.get_new_pos_guid(new_repo_pos.parent_position)
-            if not new_parent_pos_guid:
-                logger.warning(
-                    "\nInvalid operation: cannot find new parent. "
-                    "{}\n".format(operation))
-                operation['is_valid'] = False
-                return need_number_change, need_move, need_merge
+        old_parent_pos_guid = self.positions_mapping.get_old_pos_guid(old_repo_pos.parent_position)
+        new_parent_pos_guid = self.positions_mapping.get_new_pos_guid(new_repo_pos.parent_position)
+        if not new_parent_pos_guid:
+            logger.warning(
+                "\nInvalid operation: cannot find new parent. "
+                "{}\n".format(operation))
+            operation['is_valid'] = False
+            return need_number_change, need_move, need_merge
 
-            if old_parent_pos_guid != new_parent_pos_guid:
-                old_parent_new_guid = self.positions_mapping.get_old_pos_new_guid(old_repo_pos.parent_position)
-                # if current parent is merged into the future parent, no need to move
-                if old_parent_new_guid != new_parent_pos_guid:
-                    need_move = True
+        # move operation is when parent changes except if the parent is
+        # merged into the new parent
+        if old_parent_pos_guid != new_parent_pos_guid:
+            old_parent_new_guid = self.positions_mapping.get_old_pos_new_guid(old_repo_pos.parent_position)
+            # if current parent is merged into the future parent, no need to move
+            if old_parent_new_guid != new_parent_pos_guid:
+                need_move = True
 
-            # check if number change is necessary
-            if need_move or new_repo_pos.reference_number_prefix != old_repo_pos.reference_number_prefix:
-                need_number_change = True
+        # check if number change is necessary
+        if need_move or new_repo_pos.reference_number_prefix != old_repo_pos.reference_number_prefix:
+            need_number_change = True
 
         return need_number_change, need_move, need_merge
 

--- a/opengever/maintenance/scripts/repository_migration.py
+++ b/opengever/maintenance/scripts/repository_migration.py
@@ -908,7 +908,7 @@ class RepositoryExcelAnalyser(object):
 
             # permission
             'Ignorierte Bewilligungen',
-            'Vorherige Lokalen Rollen entfernt'
+            'Vorherige Lokalen Rollen entfernt',
             'Bewilligungen',
         ]
 

--- a/opengever/maintenance/scripts/repository_migration.py
+++ b/opengever/maintenance/scripts/repository_migration.py
@@ -1427,7 +1427,11 @@ def main():
     analyser_path = os.path.join(options.output_directory, "analyser.json")
     with open(analyser_path, "w") as outfile:
         analyser_data = {
-            'position_mapping': analyser.positions_mapping,
+            'position_mapping': {
+                'old_pos_guid': analyser.positions_mapping.old_pos_guid,
+                'new_pos_guid': analyser.positions_mapping.new_pos_guid,
+                'old_pos_new_guid': analyser.positions_mapping.old_pos_new_guid
+            },
             'analysed_rows': analyser.analysed_rows,
         }
         json.dump(analyser_data, outfile, default=vars)

--- a/opengever/maintenance/scripts/repository_migration.py
+++ b/opengever/maintenance/scripts/repository_migration.py
@@ -947,7 +947,7 @@ class RepositoryExcelAnalyser(object):
 
 class RepositoryMigrator(object):
 
-    def __init__(self, operations_list, dry_run):
+    def __init__(self, operations_list, dry_run=False):
         self.operations_list = operations_list
         self.dry_run = dry_run
         self._reference_repository_mapping = None

--- a/opengever/maintenance/scripts/repository_migration.py
+++ b/opengever/maintenance/scripts/repository_migration.py
@@ -260,7 +260,7 @@ class SkipTaskSyncWith(MonkeyPatch):
     def __call__(self):
         from opengever.globalindex.model.task import Task
 
-        def sync_with(self, plone_task):
+        def sync_with(self, plone_task, graceful=False):
             """Sync this task instace with its corresponding plone taks."""
             tasks_to_sync.add(plone_task.UID())
             return

--- a/opengever/maintenance/scripts/repository_migration.py
+++ b/opengever/maintenance/scripts/repository_migration.py
@@ -44,6 +44,7 @@ from opengever.base.role_assignments import ASSIGNMENT_VIA_SHARING
 from opengever.base.role_assignments import RoleAssignmentManager
 from opengever.base.role_assignments import SharingRoleAssignment
 from opengever.base.schemadump.config import ROLES_BY_SHORTNAME
+from opengever.base.utils import unrestrictedUuidToObject
 from opengever.bundle.console import add_guid_index
 from opengever.bundle.ldap import DisabledLDAP
 from opengever.bundle.sections.bundlesource import BUNDLE_PATH_KEY
@@ -64,7 +65,6 @@ from openpyxl import Workbook
 from openpyxl.styles import Font
 from plone import api
 from plone.app.uuid.utils import uuidToCatalogBrain
-from plone.app.uuid.utils import uuidToObject
 from plone.uuid.interfaces import IUUID
 from Products.CMFPlone.utils import safe_unicode
 from uuid import uuid4
@@ -628,7 +628,7 @@ class RepositoryExcelAnalyser(MigratorBase):
         # Make sure that all UIDs are valid and that for existing UIDs,
         # the title, position and description match the ones in the Excel
         if operation['uid']:
-            obj = uuidToObject(operation['uid'])
+            obj = unrestrictedUuidToObject(operation['uid'])
             if not obj:
                 logger.warning("\nInvalid operation: uid is not valid."
                                "or uid. {}\n".format(operation))
@@ -719,7 +719,7 @@ class RepositoryExcelAnalyser(MigratorBase):
                     "local roles. {}\n".format(operation))
                 operation['is_valid'] = False
             elif inheritance_blocked and has_local_roles:
-                obj = uuidToObject(operation['uid'])
+                obj = unrestrictedUuidToObject(operation['uid'])
                 if obj:
                     # newly created positions will have the local_roles set
                     # in the pipeline
@@ -979,7 +979,7 @@ class RepositoryMigrator(MigratorBase):
 
     def add_to_reindexing_queue(self, uid, idxs, with_children=False):
         self.to_reindex[uid].update(idxs)
-        obj = uuidToObject(uid)
+        obj = unrestrictedUuidToObject(uid)
         if not with_children:
             return
 
@@ -1030,7 +1030,7 @@ class RepositoryMigrator(MigratorBase):
         for i, item in enumerate(items):
             log_progress(i, n_tot, 1)
             parent = self.guid_to_object(item['new_parent_guid'])
-            repo = uuidToObject(item['uid'])
+            repo = unrestrictedUuidToObject(item['uid'])
             if not parent or not repo:
                 raise Exception('No parent or repo found for {}'.format(item))
 
@@ -1044,7 +1044,7 @@ class RepositoryMigrator(MigratorBase):
         for i, item in enumerate(items):
             log_progress(i, n_tot, 1)
             target = self.guid_to_object(item['new_parent_guid'])
-            repo = uuidToObject(item['uid'])
+            repo = unrestrictedUuidToObject(item['uid'])
             if not target or not repo:
                 raise Exception('No target or repo found for {}'.format(item))
 
@@ -1070,7 +1070,7 @@ class RepositoryMigrator(MigratorBase):
         n_tot = len(items)
         for i, item in enumerate(items):
             log_progress(i, n_tot, 5)
-            repo = uuidToObject(item['uid'])
+            repo = unrestrictedUuidToObject(item['uid'])
             referenceprefix.IReferenceNumberPrefix(repo).reference_number_prefix = item['new_number']
             parents.add(aq_parent(aq_inner(repo)))
             self.add_to_reindexing_queue(
@@ -1102,7 +1102,7 @@ class RepositoryMigrator(MigratorBase):
         n_tot = len(items)
         for i, item in enumerate(items):
             log_progress(i, n_tot, 1)
-            repo = uuidToObject(item['uid'])
+            repo = unrestrictedUuidToObject(item['uid'])
 
             # Rename
             repo.title_de = item['new_title']
@@ -1122,7 +1122,7 @@ class RepositoryMigrator(MigratorBase):
         n_tot = len(items)
         for i, item in enumerate(items):
             log_progress(i, n_tot, 5)
-            repo = uuidToObject(item['uid'])
+            repo = unrestrictedUuidToObject(item['uid'])
             if not repo:
                 continue
 
@@ -1138,7 +1138,7 @@ class RepositoryMigrator(MigratorBase):
         n_tot = len(items)
         for i, item in enumerate(items):
             log_progress(i, n_tot, 5)
-            repo = uuidToObject(item['uid'])
+            repo = unrestrictedUuidToObject(item['uid'])
             self._set_permissions_on_object(repo, item['permissions'])
             if not self.dry_run:
                 transaction.commit()
@@ -1174,7 +1174,7 @@ class RepositoryMigrator(MigratorBase):
         n_tot = len(self.to_reindex)
         for i, (uid, idxs) in enumerate(self.to_reindex.items()):
             log_progress(i, n_tot)
-            obj = uuidToObject(uid)
+            obj = unrestrictedUuidToObject(uid)
             if not obj:
                 logger.error("Could not find {} to reindex. Skipping".format(uid))
                 continue
@@ -1198,7 +1198,7 @@ class RepositoryMigrator(MigratorBase):
                 # new position was created
                 obj = self.guid_to_object(operation['new_position_guid'])
             elif operation['uid']:
-                obj = uuidToObject(operation['uid'])
+                obj = unrestrictedUuidToObject(operation['uid'])
                 if operation['need_merge']:
                     # position was deleted
                     if obj:
@@ -1303,7 +1303,7 @@ class TaskSyncer(object):
         """Syncs all plone tasks with their model
         """
         for uid in self.tasks_to_sync:
-            obj = uuidToObject(uid)
+            obj = unrestrictedUuidToObject(uid)
             obj.sync()
 
 

--- a/opengever/maintenance/scripts/repository_migration.py
+++ b/opengever/maintenance/scripts/repository_migration.py
@@ -559,7 +559,9 @@ class RepositoryExcelAnalyser(object):
             obj = brain.getObject()
             if not IAnnotations(obj).get(BUNDLE_GUID_KEY):
                 IAnnotations(obj)[BUNDLE_GUID_KEY] = uuid4().hex[:8]
-                obj.reindexObject(idxs=['bundle_guid'])
+            # reindex, whether the guid was already here or not, to make sure
+            # it's also in the catalog
+            obj.reindexObject(idxs=['bundle_guid'])
 
     def get_reporoot_and_guid(self):
         brains = self.catalog.unrestrictedSearchResults(

--- a/opengever/maintenance/scripts/repository_migration.py
+++ b/opengever/maintenance/scripts/repository_migration.py
@@ -461,10 +461,18 @@ class PositionsMapping(object):
         return self.reference_repository_mapping.get(position)
 
     def _create_mapping(self, operations):
-        # we split the operations so as to first treat all rows where the reference
-        # number is not changed, then creation operations and finally move and
-        # merge operations. This will help optimize the operations we will
-        # execute in the end.
+        """
+        we split the operations so as to first treat all rows where the reference
+        number is not changed, then creation operations and finally move and
+        merge operations. This will help optimize the operations we will
+        execute in the end, as new_pos_guid will contain the guid of
+        the object corresponding from the first operation pointing to that
+        position, all other operations pointing to that new position will be
+        considered merges. We therefore want to make sure that if one position
+        is unchanged and another merged into it, we do not instead move
+        the second one and merge the first one into it instead (same result
+        but inefficient).
+        """
         unchanged = []
         creations = []
         moves_or_merges = []

--- a/opengever/maintenance/scripts/repository_migration.py
+++ b/opengever/maintenance/scripts/repository_migration.py
@@ -191,66 +191,6 @@ class PatchDisableLDAP(MonkeyPatch):
         self.patch_refs(DisabledLDAP, '__exit__', __exit__)
 
 
-class PatchTaskSyncWith(MonkeyPatch):
-    """ We skip syncing the predecessor as this uses IntIds to resolve it,
-    which fails in the HBA migration as IntIds rely on path and also get
-    updated in an event handler. It is fine to not update the predecessor
-    as it anyway does not change during a move operation.
-    """
-
-    def __call__(self):
-        from opengever.globalindex.model.task import Task
-
-        def sync_with(self, plone_task):
-            """Sync this task instace with its corresponding plone taks."""
-            self.title = plone_task.safe_title
-            self.text = plone_task.text
-
-            self.breadcrumb_title = plone_task.get_breadcrumb_title(
-                self.MAX_BREADCRUMB_LENGTH,
-                )
-
-            self.physical_path = plone_task.get_physical_path()
-            self.review_state = plone_task.get_review_state()
-            self.icon = plone_task.getIcon()
-            self.responsible = plone_task.responsible
-            self.is_private = plone_task.is_private
-            self.issuer = plone_task.issuer
-            self.deadline = plone_task.deadline
-            self.completed = plone_task.date_of_completion
-
-            # we need to have python datetime objects for make it work with sqlite
-            self.modified = plone_task.modified().asdatetime().replace(tzinfo=None)
-            self.task_type = plone_task.task_type
-            self.is_subtask = plone_task.get_is_subtask()
-            self.sequence_number = plone_task.get_sequence_number()
-            self.reference_number = plone_task.get_reference_number()
-
-            self.containing_dossier = safe_unicode(
-                plone_task.get_containing_dossier_title(),
-                )
-
-            self.dossier_sequence_number = plone_task.get_dossier_sequence_number()
-            self.assigned_org_unit = plone_task.responsible_client
-            self.principals = plone_task.get_principals()
-
-            self.predecessor = self.query_predecessor(
-                *plone_task.get_predecessor_ids()
-                )
-
-            self.containing_subdossier = safe_unicode(
-                plone_task.get_containing_subdossier(),
-                )
-
-            # predecessor = plone_task.get_tasktemplate_predecessor()
-            # if predecessor:
-            #     self.tasktemplate_predecessor = predecessor.get_sql_object()
-
-            self.sync_reminders(plone_task)
-
-        self.patch_refs(Task, 'sync_with', sync_with)
-
-
 class SkipTaskSyncWith(MonkeyPatch):
     """ We skip syncing the tasks altogether, as migration is not done with the
     productive OGDS. We will then sync the tasks at a later stage. We therefore store
@@ -1409,9 +1349,7 @@ def main():
     PatchCommitSection()()
     PatchReindexContainersSection()()
     PatchReportSection()()
-    if options.sync_task:
-        PatchTaskSyncWith()()
-    else:
+    if not options.sync_task:
         SkipTaskSyncWith()()
     PatchDisableLDAP()()
     SkipDocPropsUpdate()()

--- a/opengever/maintenance/scripts/repository_migration.py
+++ b/opengever/maintenance/scripts/repository_migration.py
@@ -644,7 +644,7 @@ class RepositoryExcelAnalyser(MigratorBase):
                     logger.warning("\nInvalid operation: incorrect position."
                                    "{}\n".format(operation))
                     operation['is_valid'] = False
-                if (obj.description or old_repo_pos.description) and obj.description != old_repo_pos.description:
+                if (obj.description or old_repo_pos.description) and obj.description.strip() != old_repo_pos.description.strip():
                     logger.warning("\nInvalid operation: incorrect description."
                                    "{}\n".format(operation))
                     operation['is_valid'] = False

--- a/opengever/maintenance/scripts/repository_migration.py
+++ b/opengever/maintenance/scripts/repository_migration.py
@@ -642,13 +642,6 @@ class RepositoryExcelAnalyser(object):
         if any([not op['is_valid'] for op in self.analysed_rows]):
             self.is_valid = False
 
-    def operation_by_old_refnum(self, reference_number):
-        refnum = cleanup_position(reference_number)
-        for op in self.analysed_rows:
-            if op['old_repo_pos'].position == refnum:
-                return op
-        return None
-
     def validate_operation(self, operation):
         """Make sure that operation satisfies all necessary conditions and add
         is_valid, repository_depth_violated and leaf_node_violated and
@@ -876,10 +869,6 @@ class RepositoryExcelAnalyser(object):
 
         return None
 
-    def get_object_for_position(self, position):
-        mapping = self.get_repository_reference_mapping()
-        return mapping.get(position)
-
     def guid_to_object(self, guid):
         return self.catalog(bundle_guid=guid)[0].getObject()
 
@@ -1064,15 +1053,6 @@ class RepositoryMigrator(object):
 
         with DisabledLDAP(portal):
             transmogrifier(u'opengever.bundle.oggbundle')
-
-    def guid_to_object(self, guid):
-        return self.catalog(bundle_guid=guid)[0].getObject()
-
-    def uid_or_guid_to_object(self, uid_or_guid):
-        obj = uuidToObject(uid_or_guid)
-        if not obj:
-            obj = self.catalog(bundle_guid=uid_or_guid)[0].getObject()
-        return obj
 
     def move_branches(self, items):
         logger.info("\n\nMoving...\n")

--- a/opengever/maintenance/scripts/update_object_ids.py
+++ b/opengever/maintenance/scripts/update_object_ids.py
@@ -48,8 +48,8 @@ def marmoset_patch(old, new, extra_globals={}):
 
 
 # deferred arguments will be injected via globals while patching
-def deferred_sync_task(obj, event):
-    deferred_arguments.append((obj, event))
+def deferred_sync_task(obj, event, graceful=False):
+    deferred_arguments.append((obj, event, graceful))
 
 
 class DeferredOrDisabledEventHandlers(object):
@@ -87,11 +87,11 @@ class DeferredOrDisabledEventHandlers(object):
         self._orig_journal_factory = None
 
     def perform_deferred_task_syncing(self):
-        for obj, event in self.deferred_sync_task_call_arguments:
+        for obj, event, graceful in self.deferred_sync_task_call_arguments:
             # this is the code that would be run by `sync_task`.
             if IContainerModifiedEvent.providedBy(event):
                 return
-            TaskSqlSyncer(obj, event).sync()
+            TaskSqlSyncer(obj, event, graceful).sync()
 
         self.deferred_sync_task_call_arguments = None
 


### PR DESCRIPTION
To finally get a few benefits, I had to modify the migration script quite a bit. Before we were generating a mapping of old and new positions in the order of the rows in the excel file and at the same time analysing the corresponding operation. This made the whole script very sensitive to operation ordering in the excel file, and defining the correct order was really not always easy (as the operations themselves actually happen in the order `create`, `move`, `merge`). Moreover we were sometimes using `position`s (i.e. reference numbers) to identify the parents (for example for creation operations). All the creation operations happening first,  can lead to temporarily having 2 repository folders with the same reference number (e.g. are creating a new repofolder having the same number as an already existing one which will be moved later in the migration), which in turn would lead to issues identifying the correct parent in other creation operations. To solve these issues (and also better identify some move operations), we now:
- assign a `guid` to all existing repository folders
- construct two mappings:
  - old (initial) positions to its guid
  - new (final) positions to their guid (we assign a guid here to positions that will be created later)
- Once this is done we go a second time over all the rows in the excel and identify to what operation it will correspond

With this it is easier to correctly identify different operation types and the identification is less dependent on the order in the excel file.

Also note that I've updated the corresponding tests in opengever.core, to make sure the migration script was still working as before and added a new test for the newly supported edge cases (see https://github.com/4teamwork/opengever.core/pull/6792, last 5 commits)

For https://4teamwork.atlassian.net/browse/CA-3245 and https://4teamwork.atlassian.net/browse/CA-3243