### PR TITLE
Set Metadata when creating new positions in repository migration. 

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 1.0 (unreleased)
 ----------------
 
+- Set Metadata when creating new positions in repository migration. [njohner]
+
 - Handle new argument "graceful" of task syncer in ObjectIDUpdater. [njohner]
 
 - Add extended health checks (Nightly Jobs and OGDS sync). [lgraf]

--- a/opengever/maintenance/scripts/repository_migration.py
+++ b/opengever/maintenance/scripts/repository_migration.py
@@ -6,7 +6,7 @@ migration.
 optional arguments:
   -o : path to a folder where output should be saved. The folder will be created.
        This defaults to var/migration-TIMESTAMP
-  -s : sync tasks. By default tasks are not synced as the migration is not
+  -t : sync tasks. By default tasks are not synced as the migration is not
        performed on the original OGDS. Instead UIDs of tasks that will need
        syncing are stored and dumped in a json file that can then be used
        to sync the tasks.

--- a/opengever/maintenance/scripts/repository_migration.py
+++ b/opengever/maintenance/scripts/repository_migration.py
@@ -38,6 +38,7 @@ from Acquisition import aq_parent
 from collections import defaultdict
 from collections import namedtuple
 from collective.transmogrifier.transmogrifier import Transmogrifier
+from copy import deepcopy
 from opengever.base.behaviors.classification import IClassification
 from opengever.base.behaviors.lifecycle import ILifeCycle
 from opengever.base.default_values import get_persisted_value_for_field
@@ -107,6 +108,16 @@ metadata_fields = (
     ILifeCycle["archival_value_annotation"],
     ILifeCycle["custody_period"],
                    )
+
+MAPPED_FIELDS = deepcopy(MAPPED_FIELDS)
+# Mapping used in StaSG migration for some reason
+MAPPED_FIELDS["archival_value"].update({
+    u'ng': u'unchecked',
+    u'an': u'prompt',
+    u'ar': u'archival worthy',
+    u'na': u'not archival worthy',
+    u'sa': u'archival worthy with sampling',
+                                       })
 
 
 def log_progress(i, tot, step=100):

--- a/opengever/maintenance/scripts/repository_migration.py
+++ b/opengever/maintenance/scripts/repository_migration.py
@@ -42,6 +42,7 @@ from copy import deepcopy
 from opengever.base.behaviors.classification import IClassification
 from opengever.base.behaviors.lifecycle import ILifeCycle
 from opengever.base.default_values import get_persisted_value_for_field
+from opengever.base.default_values import object_has_value_for_field
 from opengever.base.indexes import sortable_title
 from opengever.base.interfaces import IReferenceNumber
 from opengever.base.interfaces import IReferenceNumberFormatter
@@ -928,7 +929,11 @@ class RepositoryExcelAnalyser(MigratorBase):
         metadata = operation["metadata"]
         try:
             for field in metadata_fields:
-                assert(get_persisted_value_for_field(obj, field) == metadata.get(field.getName()))
+                if object_has_value_for_field(obj, field):
+                    persisted_value = get_persisted_value_for_field(obj, field)
+                else:
+                    persisted_value = None
+                assert(persisted_value == metadata.get(field.getName()))
         except AssertionError:
             logger.warning("\nMetadata mismatch. Metadata will not be "
                            "updated during migration! {}\n".format(operation))
@@ -1336,7 +1341,11 @@ class RepositoryMigrator(MigratorBase):
         for field in metadata_fields:
             if field.getName() not in metadata:
                 continue
-            self.checkEqual(uid, get_persisted_value_for_field(obj, field),
+            if object_has_value_for_field(obj, field):
+                persisted_value = get_persisted_value_for_field(obj, field)
+            else:
+                persisted_value = None
+            self.checkEqual(uid, persisted_value,
                             metadata.get(field.getName()), err_msg)
 
     def checkObjectConsistency(self, obj):


### PR DESCRIPTION
We add support for the metadata fields (`IClassification` and `ILifeCycle` behaviours) for repository folders created during repository migration.

For [CA-3245]

[CA-3245]: https://4teamwork.atlassian.net/browse/CA-3245?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ