### PR TITLE
Sort misconfigured objects by path in ParticipantsChecker.

### DIFF
--- a/opengever/maintenance/scripts/check_workspace_participants.py
+++ b/opengever/maintenance/scripts/check_workspace_participants.py
@@ -34,7 +34,8 @@ class ParticipantsChecker(object):
 
     def check_participants(self):
         brains = self.catalog.unrestrictedSearchResults(
-            portal_type='opengever.workspace.folder')
+            portal_type='opengever.workspace.folder',
+            sort_on="path")
 
         for i, brain in enumerate(brains, 1):
             obj = brain.getObject()


### PR DESCRIPTION
Sorting makes the output a bit easier to read. I've now also added a new column with the titles of the objects, that also helps the customer assess what to do with these objects.

For https://4teamwork.atlassian.net/browse/CA-3712