### PR TITLE
Implement fixing of participations for migrated teamraum deployments.

### DIFF
--- a/opengever/maintenance/scripts/check_workspace_participants.py
+++ b/opengever/maintenance/scripts/check_workspace_participants.py
@@ -202,7 +202,7 @@ class ParticipantsChecker(object):
                 self.misconfigured.add_row((
                     self.get_url(obj),
                     self.get_titles(obj),
-                    'x' if missing_admin else'',
+                    'x' if missing_admin else '',
                     'x' if missing_local_roles_block else '',
                     'x' if with_multiple_roles else '',
                     u" ".join([participant["userid"] for participant in misconfigured_participants])))

--- a/opengever/maintenance/scripts/check_workspace_participants.py
+++ b/opengever/maintenance/scripts/check_workspace_participants.py
@@ -193,6 +193,7 @@ class ParticipantsChecker(object):
 
         for i, obj in enumerate(self.workspaces_and_workspace_folders, 1):
             manager = ManageParticipants(obj, getRequest())
+
             misconfigured_participants = self.get_misconfigured_participants(obj, manager)
             missing_local_roles_block = self.is_local_roles_block_missing(obj, manager)
             missing_admin = self.is_admin_missing(obj, manager)
@@ -231,6 +232,12 @@ class ParticipantsChecker(object):
         corrections = []
         for i, obj in enumerate(self.workspaces_and_workspace_folders, 1):
             manager = ManageParticipants(obj, getRequest())
+
+            # Overwrite the require_admin_assignment to avoid failures
+            # when deleting / updating participations on object where no admin
+            # is defined.
+            manager._require_admin_assignment = lambda: True
+
             former_participants = deepcopy(manager.get_participants())
 
             roles_cleaned_up = self.correct_participants_with_multiple_roles(obj, manager)

--- a/opengever/maintenance/scripts/check_workspace_participants.py
+++ b/opengever/maintenance/scripts/check_workspace_participants.py
@@ -213,8 +213,8 @@ class ParticipantsChecker(object):
         return "{}:{}".format(participant["userid"], roles)
 
     def format_participants(self, participants):
-        return "\n".join([self._format_participant(participant)
-                          for participant in participants])
+        return '"{}"'.format("\n".join([self._format_participant(participant)
+                                        for participant in participants]))
 
     @staticmethod
     def _format_participant_with_former_roles(participant):
@@ -223,8 +223,9 @@ class ParticipantsChecker(object):
         return "{}:{} -> {}".format(participant["userid"], former_roles, roles)
 
     def format_roles_cleaned_up(self, roles_cleaned_up):
-        return "\n".join([self._format_participant_with_former_roles(participant)
-                          for participant in roles_cleaned_up])
+        return '"{}"'.format('\n'.join(
+            [self._format_participant_with_former_roles(participant)
+             for participant in roles_cleaned_up]))
 
     def correct_misconfigurations(self):
         corrections = []

--- a/opengever/maintenance/scripts/check_workspace_participants.py
+++ b/opengever/maintenance/scripts/check_workspace_participants.py
@@ -42,7 +42,7 @@ class ParticipantsChecker(object):
     def get_titles(self, obj):
         titles = []
         self._recurse_title(obj, titles)
-        return " | ".join(reversed(titles))
+        return '"{}"'.format(" | ".join(reversed(titles)))
 
     def _recurse_title(self, obj, titles):
         titles.append(obj.Title())

--- a/opengever/maintenance/scripts/check_workspace_participants.py
+++ b/opengever/maintenance/scripts/check_workspace_participants.py
@@ -273,7 +273,7 @@ def main():
     parser = setup_option_parser()
 
     parser.add_option(
-        '-f', '--fix', action='store_true', default=None,
+        '--fix', action='store_true', default=None,
         help='Correct the permissions',
         dest='fix')
 
@@ -313,6 +313,16 @@ def main():
             'corrected_workspace_folders', extension="csv")
         with open(log_filename, "w") as logfile:
             participants_checker.corrections_table.write_csv(logfile)
+
+        # validate correction
+        participants_checker.check_misconfigurations()
+        sys.stdout.write("\n\nTable of all misconfigured dossiers:\n")
+        sys.stdout.write(participants_checker.misconfigured.generate_output())
+
+        log_filename = LogFilePathFinder().get_logfile_path(
+            'misconfigured_workspace_folders_after_correction', extension="csv")
+        with open(log_filename, "w") as logfile:
+            participants_checker.misconfigured.write_csv(logfile)
 
         if not options.dryrun:
             transaction.commit()

--- a/opengever/maintenance/scripts/check_workspace_participants.py
+++ b/opengever/maintenance/scripts/check_workspace_participants.py
@@ -220,10 +220,19 @@ def main():
         help='Correct the permissions',
         dest='fix')
 
+    parser.add_option(
+        '-n', '--dry-run', dest='dryrun',
+        default=False, action="store_true",
+        help='Dryrun, do not commit changes. Only relevant for correction.')
+
     (options, args) = parser.parse_args()
 
     app = setup_app()
     setup_plone(app)
+
+    if options.dryrun:
+        print('Performing dryrun!\n')
+        transaction.doom()
 
     participants_checker = ParticipantsChecker()
     if not options.fix:
@@ -248,7 +257,8 @@ def main():
         with open(log_filename, "w") as logfile:
             participants_checker.corrections_table.write_csv(logfile)
 
-        transaction.commit()
+        if not options.dryrun:
+            transaction.commit()
 
 
 if __name__ == '__main__':

--- a/opengever/maintenance/utils.py
+++ b/opengever/maintenance/utils.py
@@ -154,7 +154,7 @@ class TextTable(object):
         return [[cell[i] if i < len(cell) else "" for cell in wrapped_row] for i in range(nlines + 1)]
 
     def write_csv(self, file):
-        frmtstr = u" , ".join(u"{}" for i in range(self.ncols))
+        frmtstr = u",".join(u"{}" for i in range(self.ncols))
         for row in self.data:
             file.write(safe_utf8(frmtstr.format(*row) + u"\n"))
 


### PR DESCRIPTION
We modify the script used to check whether local roles respect the restrictions imposed in the new teamraum to allow correcting them. What the script will do:
- Correct participations with multiple roles: each participant should only have a single role (we keep the one giving the most permissions)
- Remove participants with same roles (or lower permissions) as on parent and inheritance that is not blocked.
- Delete participants that are not participants on the parent object
- Block inheritance on objects with local roles and copy roles from parent.

For https://4teamwork.atlassian.net/browse/CA-3712 and https://4teamwork.atlassian.net/browse/CA-3713