### PR TITLE
Bump tests: opengever.core 2022.4.1

### DIFF
--- a/test-og-2022.4.x.cfg
+++ b/test-og-2022.4.x.cfg
@@ -1,7 +1,7 @@
 [buildout]
 extends =
     https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
-    https://raw.githubusercontent.com/4teamwork/opengever.core/2022.4.0/versions.cfg
+    https://raw.githubusercontent.com/4teamwork/opengever.core/2022.4.1/versions.cfg
     base-testing.cfg
 
 [test]


### PR DESCRIPTION
Bump tests: opengever.core `2022.4.1`.