### PR TITLE
Add script to globally assign role to principal.

### DIFF
--- a/opengever/maintenance/scripts/assign_global_role.py
+++ b/opengever/maintenance/scripts/assign_global_role.py
@@ -1,0 +1,44 @@
+"""
+Globally assigns a given role to a principal.
+
+Example Usage:
+
+    bin/instance run assign_global_role.py <role> <principal>
+    bin/instance run assign_global_role.py 'PropertySheetsManager' 'some-group-id'
+"""
+from opengever.maintenance.debughelpers import setup_app
+from opengever.maintenance.debughelpers import setup_plone
+from plone import api
+import argparse
+import sys
+import transaction
+
+
+def assign_gobal_role(plone, args):
+    role = args.role
+    principal = args.principal
+
+    acl_users = api.portal.get_tool("acl_users")
+    role_manager = acl_users.portal_role_manager
+    valid_roles = role_manager.validRoles()
+
+    if role not in valid_roles:
+        raise Exception("Role %r not found. Valid roles are: %r" % (role, valid_roles))
+
+    role_manager.assignRoleToPrincipal(role, principal)
+    print("Assigned role %r to principal %r" % (role, principal))
+
+
+if __name__ == "__main__":
+    app = setup_app()
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("role", help="Role Name")
+    parser.add_argument("principal", help="Principal ID")
+
+    args = parser.parse_args(sys.argv[3:])
+
+    plone = setup_plone(setup_app())
+
+    assign_gobal_role(plone, args)
+    transaction.commit()


### PR DESCRIPTION
Maintenance script that allows to globally assign a role to a principal (via `portal_role_manager`).

For [CA-2880](https://4teamwork.atlassian.net/browse/CA-2880)