### PR TITLE
Extend script to create InterGEVER service user and assign roles

### DIFF
--- a/opengever/maintenance/scripts/connect_to_intergever.py
+++ b/opengever/maintenance/scripts/connect_to_intergever.py
@@ -3,7 +3,7 @@ Adds a webaction on Dossiers to launch eCH-0147 export via Intergever.
 
 Example Usage:
 
-    bin/instance run add_intergever_webaction.py sgtest
+    bin/instance run connect_to_intergever.py sgtest
 """
 from opengever.api.validation import get_validation_errors
 from opengever.maintenance.debughelpers import setup_app


### PR DESCRIPTION
This extends the script to connect a GEVER deployment to InterGEVER with
- creation of the `intergever.app` service user (if it doesn't already exist)
- assigning the required roles (if not already assigned yet)

I already tested this script like this on `dev.onegovgever.ch`

For [CA-3274](https://4teamwork.atlassian.net/browse/CA-3274)