### PR TITLE
Allow removing Owner role when making repository read-only.

### DIFF
--- a/opengever/maintenance/scripts/make_repository_readonly.py
+++ b/opengever/maintenance/scripts/make_repository_readonly.py
@@ -76,6 +76,7 @@ class MakeRepositoryReadOnly(object):
         u"Editor",
         u"Publisher",
         u"Reviewer",
+        u"Owner",
     )
 
     OPEN_STATES = DOSSIER_STATES_OPEN + OPEN_TASK_STATES


### PR DESCRIPTION
There are some objects where the `Owner` role is set through our role assignments (https://github.com/4teamwork/opengever.core/blob/master/opengever/base/role_assignments.py#L380), so it also needs to be allowed to replace that role with `Reader`, especially since that role does give various permissions.

For https://4teamwork.atlassian.net/browse/CA-3968