### PR TITLE
Handle duplicate participation entries.

### DIFF
--- a/opengever/maintenance/scripts/sql_contact_migration.py
+++ b/opengever/maintenance/scripts/sql_contact_migration.py
@@ -145,10 +145,17 @@ class SqlContactExporter(object):
                     u'Not supported participation type: {}'.format(
                         participation.participation_type))
 
-            kub_participation = kub_handler.create_participation(
-                participant_id=participant_id,
-                roles=[role.role for role in participation.roles])
-            kub_handler.append_participation(kub_participation)
+            roles = [role.role for role in participation.roles]
+
+            if kub_handler.has_participation(participant_id):
+                existing = kub_handler.get_participation(participant_id)
+                roles = list(set(roles + existing.roles))
+                existing.roles = roles
+            else:
+                kub_participation = kub_handler.create_participation(
+                    participant_id=participant_id,
+                    roles=[role.role for role in participation.roles])
+                kub_handler.append_participation(kub_participation)
 
         if participations:
             dossier.reindexObject(idxs=["participations", "UID"])


### PR DESCRIPTION
In earlier GEVER versions it was apparently possible to store multiple
participations for one contact or org_role. On the production system we have such duplicate participations.

Additional fix for #327 ([CA-2536](https://4teamwork.atlassian.net/browse/CA-2635))