### PR TITLE
Add tests for opengever.core version 2022.16.0

### DIFF
--- a/test-og-2022.16.x.cfg
+++ b/test-og-2022.16.x.cfg
@@ -1,0 +1,9 @@
+[buildout]
+extends =
+    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
+    https://raw.githubusercontent.com/4teamwork/opengever.core/2022.16.0/versions.cfg
+    base-testing.cfg
+
+[test]
+eggs +=
+    unittest2


### PR DESCRIPTION
Add tests for opengever.core version 2022.16.0

For [CA-4085](https://4teamwork.atlassian.net/browse/CA-4085)