### PR TITLE
Dossier export can include repository and subdossier structure.

### DIFF
--- a/opengever/maintenance/scripts/export_and_close_dossiers.py
+++ b/opengever/maintenance/scripts/export_and_close_dossiers.py
@@ -13,7 +13,6 @@ from opengever.maintenance.utils import LogFilePathFinder
 from opengever.maintenance.utils import TextTable
 from opengever.workspaceclient.interfaces import IWorkspaceClientSettings
 from plone import api
-from plone import api
 from zope.component import getAdapter
 import logging
 import os


### PR DESCRIPTION
Add an option to include the repository folder structure and the subdossiers when exporting the dossiers and documents.

For https://4teamwork.atlassian.net/browse/CA-5061

[CA-5061]: https://4teamwork.atlassian.net/browse/CA-5061?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ