### PR TITLE
Add scripts used in the data recovery for GDGS

### DIFF
--- a/opengever/maintenance/scripts/extract_gdgs_documents.py
+++ b/opengever/maintenance/scripts/extract_gdgs_documents.py
@@ -1,0 +1,390 @@
+from Acquisition import aq_base
+from opengever.base.interfaces import IOpengeverBaseLayer
+from opengever.maintenance.debughelpers import setup_app
+from opengever.maintenance.debughelpers import setup_plone
+from os.path import join as pjoin
+from plone.restapi.interfaces import ISerializeToJson
+from zope.component import queryMultiAdapter
+from zope.globalrequest import getRequest
+from zope.interface import alsoProvides
+import argparse
+import errno
+import hashlib
+import json
+import os
+import shutil
+import sys
+import transaction
+
+
+# Modified objects according to this Solr query:
+# q=modified%3A%5B2023-01-23T02%3A55%3A00Z%20TO%202023-01-25T14%3A20%3A00Z%5D&rows=1000
+
+CHANGED_OBJS = [
+    "/gdgs/ordnungssystem/fuehrung-und-koordination-departement/kommunikation-und-oeffentlichkeitsarbeit/webauftritt/dossier-20042",
+    "/gdgs/ordnungssystem/fuehrung-und-koordination-departement/kommunikation-und-oeffentlichkeitsarbeit/webauftritt/dossier-20042/document-184900",
+    "/gdgs/ordnungssystem/fuehrung-und-koordination-departement/kommunikation-und-oeffentlichkeitsarbeit/webauftritt/dossier-20042/document-184919",
+    "/gdgs/ordnungssystem/fuehrung-und-koordination-departement/operative-fuehrung/aufbauorganisation/administratives-und-organisatorisches/dossier-19522/dossier-19523",
+    "/gdgs/ordnungssystem/fuehrung-und-koordination-departement/operative-fuehrung/aufbauorganisation/administratives-und-organisatorisches/dossier-19522/dossier-19523/document-184929",
+    "/gdgs/ordnungssystem/fuehrung-und-koordination-departement/operative-fuehrung/aufbauorganisation/administratives-und-organisatorisches/dossier-19522/dossier-19524/dossier-20073",
+    "/gdgs/ordnungssystem/fuehrung-und-koordination-departement/operative-fuehrung/aufbauorganisation/administratives-und-organisatorisches/dossier-19522/dossier-19524/dossier-20073/document-184884",
+    "/gdgs/ordnungssystem/fuehrung-und-koordination-departement/operative-fuehrung/aufbauorganisation/administratives-und-organisatorisches/dossier-19522/dossier-19524/dossier-20073/document-184885",
+    "/gdgs/ordnungssystem/fuehrung-und-koordination-departement/operative-fuehrung/aufbauorganisation/administratives-und-organisatorisches/dossier-19522/dossier-19524/dossier-20073/document-184930",
+    "/gdgs/ordnungssystem/fuehrung-und-koordination-departement/operative-fuehrung/aufbauorganisation/administratives-und-organisatorisches/dossier-19522/dossier-19524/dossier-20073/document-184931",
+    "/gdgs/ordnungssystem/fuehrung-und-koordination-departement/operative-fuehrung/aufbauorganisation/administratives-und-organisatorisches/dossier-19522/dossier-19524/dossier-20073/document-184932",
+    "/gdgs/ordnungssystem/fuehrung-und-koordination-departement/operative-fuehrung/aufbauorganisation/administratives-und-organisatorisches/dossier-19870",
+    "/gdgs/ordnungssystem/fuehrung-und-koordination-departement/operative-fuehrung/aufbauorganisation/administratives-und-organisatorisches/dossier-19870/document-184939",
+    "/gdgs/ordnungssystem/fuehrung-und-koordination-departement/operative-fuehrung/aufbauorganisation/administratives-und-organisatorisches/dossier-19870/document-184940",
+    "/gdgs/ordnungssystem/fuehrung-und-koordination-departement/operative-fuehrung/aufbauorganisation/administratives-und-organisatorisches/dossier-19870/document-184942",
+    "/gdgs/ordnungssystem/fuehrung-und-koordination-departement/operative-fuehrung/aufbauorganisation/administratives-und-organisatorisches/dossier-19898",
+    "/gdgs/ordnungssystem/fuehrung-und-koordination-departement/operative-fuehrung/aufbauorganisation/administratives-und-organisatorisches/dossier-19898/dossier-19899/dossier-20232",
+    "/gdgs/ordnungssystem/fuehrung-und-koordination-departement/operative-fuehrung/aufbauorganisation/administratives-und-organisatorisches/dossier-19898/dossier-19899/dossier-20232/document-184863",
+    "/gdgs/ordnungssystem/fuehrung-und-koordination-departement/operative-fuehrung/aufbauorganisation/administratives-und-organisatorisches/dossier-19898/dossier-20238",
+    "/gdgs/ordnungssystem/fuehrung-und-koordination-departement/operative-fuehrung/aufbauorganisation/administratives-und-organisatorisches/dossier-19898/dossier-20238/document-184853",
+    "/gdgs/ordnungssystem/fuehrung-und-koordination-departement/operative-fuehrung/aufbauorganisation/administratives-und-organisatorisches/dossier-19898/dossier-20238/document-184988",
+    "/gdgs/ordnungssystem/fuehrung-und-koordination-departement/operative-fuehrung/aufbauorganisation/administratives-und-organisatorisches/dossier-19898/dossier-20238/document-184989",
+    "/gdgs/ordnungssystem/fuehrung-und-koordination-departement/politische-mitwirkung/parlamentarische-vorstoesse/dossier-20202",
+    "/gdgs/ordnungssystem/fuehrung-und-koordination-departement/politische-mitwirkung/parlamentarische-vorstoesse/dossier-20202/document-184935",
+    "/gdgs/ordnungssystem/fuehrung-und-koordination-departement/politische-mitwirkung/regierungsgeschaefte/dossier-19988/dossier-20045/document-184708",
+    "/gdgs/ordnungssystem/fuehrung-und-koordination-departement/politische-mitwirkung/stellungnahmen-und-mitberichte",
+    "/gdgs/ordnungssystem/fuehrung-und-koordination-departement/politische-mitwirkung/stellungnahmen-und-mitberichte/dossier-20248",
+    "/gdgs/ordnungssystem/fuehrung-und-koordination-departement/politische-mitwirkung/stellungnahmen-und-mitberichte/dossier-20248/document-184933",
+    "/gdgs/ordnungssystem/fuehrung-und-koordination-departement/politische-mitwirkung/stellungnahmen-und-mitberichte/dossier-20248/document-184934",
+    "/gdgs/ordnungssystem/fuehrung-und-koordination-departement/politische-mitwirkung/stellungnahmen-und-mitberichte/dossier-20255",
+    "/gdgs/ordnungssystem/fuehrung-und-koordination-departement/politische-mitwirkung/stellungnahmen-und-mitberichte/dossier-20255/document-184980",
+    "/gdgs/ordnungssystem/fuehrung-und-koordination-departement/politische-mitwirkung/stellungnahmen-und-mitberichte/dossier-20255/task-1233",
+    "/gdgs/ordnungssystem/fuehrung-und-koordination-departement/politische-mitwirkung/stellungnahmen-und-mitberichte/dossier-20255/task-1233/document-184981",
+    "/gdgs/ordnungssystem/fuehrung-und-koordination-departement/politische-mitwirkung/stellungnahmen-und-mitberichte/dossier-20266",
+    "/gdgs/ordnungssystem/fuehrung-und-koordination-departement/politische-mitwirkung/stellungnahmen-und-mitberichte/dossier-20266/document-184999",
+    "/gdgs/ordnungssystem/fuehrung-und-koordination-departement/politische-mitwirkung/stellungnahmen-und-mitberichte/dossier-20266/task-1234",
+    "/gdgs/ordnungssystem/fuehrung-und-koordination-departement/politische-mitwirkung/stellungnahmen-und-mitberichte/dossier-20266/task-1234/document-184991",
+    "/gdgs/ordnungssystem/fuehrung-und-koordination-departement/politische-mitwirkung/stellungnahmen-und-mitberichte/dossier-20266/task-1234/document-184992",
+    "/gdgs/ordnungssystem/fuehrung-und-koordination-departement/politische-mitwirkung/stellungnahmen-und-mitberichte/dossier-20266/task-1234/document-184993",
+    "/gdgs/ordnungssystem/fuehrung-und-koordination-departement/politische-mitwirkung/stellungnahmen-und-mitberichte/dossier-20266/task-1234/document-184994",
+    "/gdgs/ordnungssystem/fuehrung-und-koordination-departement/politische-mitwirkung/stellungnahmen-und-mitberichte/dossier-20266/task-1234/document-184995",
+    "/gdgs/ordnungssystem/fuehrung-und-koordination-departement/politische-mitwirkung/stellungnahmen-und-mitberichte/dossier-20267",
+    "/gdgs/ordnungssystem/fuehrung-und-koordination-departement/politische-mitwirkung/stellungnahmen-und-mitberichte/dossier-20267/document-185002",
+    "/gdgs/ordnungssystem/fuehrung-und-koordination-departement/politische-mitwirkung/stellungnahmen-und-mitberichte/dossier-20267/task-1235",
+    "/gdgs/ordnungssystem/fuehrung-und-koordination-departement/politische-mitwirkung/stellungnahmen-und-mitberichte/dossier-20267/task-1235/document-185000",
+    "/gdgs/ordnungssystem/fuehrung-und-koordination-departement/politische-mitwirkung/stellungnahmen-und-mitberichte/dossier-20267/task-1235/document-185001",
+    "/gdgs/ordnungssystem/fuehrung-und-koordination-generalsekretariat/operative-fuehrung/aufbauorganisation/kantonsapotheke/wissensmanagement/dossier-12260/document-154467",
+    "/gdgs/ordnungssystem/fuehrung-und-koordination-generalsekretariat/operative-fuehrung/aufbauorganisation/kantonsapotheke/wissensmanagement/dossier-19832",
+    "/gdgs/ordnungssystem/fuehrung-und-koordination-generalsekretariat/operative-fuehrung/aufbauorganisation/kantonsapotheke/wissensmanagement/dossier-19832/document-184947",
+    "/gdgs/ordnungssystem/fuehrung-und-koordination-generalsekretariat/operative-fuehrung/aufbauorganisation/kantonsapotheke/wissensmanagement/dossier-19832/document-184949",
+    "/gdgs/ordnungssystem/fuehrung-und-koordination-generalsekretariat/operative-fuehrung/aufbauorganisation/kantonsapotheke/wissensmanagement/dossier-19832/document-184950",
+    "/gdgs/ordnungssystem/fuehrung-und-koordination-generalsekretariat/operative-fuehrung/aufbauorganisation/lernende/dossier-17097/dossier-17098/dossier-17532/document-161656",
+    "/gdgs/ordnungssystem/fuehrung-und-koordination-generalsekretariat/operative-fuehrung/aufbauorganisation/rechtsdienst/wissensmanagement/dossier-16043/dossier-18089",
+    "/gdgs/ordnungssystem/fuehrung-und-koordination-generalsekretariat/operative-fuehrung/aufbauorganisation/rechtsdienst/wissensmanagement/dossier-16043/dossier-18089/document-168621",
+    "/gdgs/ordnungssystem/fuehrung-und-koordination-generalsekretariat/operative-fuehrung/aufbauorganisation/rechtsdienst/wissensmanagement/dossier-16043/dossier-18089/document-168625",
+    "/gdgs/ordnungssystem/fuehrung-und-koordination-generalsekretariat/operative-fuehrung/aufbauorganisation/rechtsdienst/wissensmanagement/dossier-16043/dossier-18089/document-170427",
+    "/gdgs/ordnungssystem/fuehrung-und-koordination-generalsekretariat/operative-fuehrung/aufbauorganisation/rechtsdienst/wissensmanagement/dossier-16043/dossier-18089/document-184892",
+    "/gdgs/ordnungssystem/fuehrung-und-koordination-generalsekretariat/operative-fuehrung/aufbauorganisation/rechtsdienst/wissensmanagement/dossier-16043/dossier-18089/task-1231",
+    "/gdgs/ordnungssystem/fuehrung-und-koordination-generalsekretariat/operative-fuehrung/aufbauorganisation/rechtsdienst/wissensmanagement/dossier-16043/dossier-18089/task-1232",
+    "/gdgs/ordnungssystem/support-und-ressourcen-departement/finanzen/planung/dossier-17659/dossier-17661/dossier-17681",
+    "/gdgs/ordnungssystem/support-und-ressourcen-departement/finanzen/planung/dossier-17659/dossier-17661/dossier-17681/document-184881",
+    "/gdgs/ordnungssystem/support-und-ressourcen-departement/finanzen/rechnungsfuehrung-und-zahlungsabwicklung",
+    "/gdgs/ordnungssystem/support-und-ressourcen-departement/finanzen/rechnungsfuehrung-und-zahlungsabwicklung/dossier-15874",
+    "/gdgs/ordnungssystem/support-und-ressourcen-departement/finanzen/rechnungsfuehrung-und-zahlungsabwicklung/dossier-15874/document-184665",
+    "/gdgs/ordnungssystem/support-und-ressourcen-departement/finanzen/rechnungsfuehrung-und-zahlungsabwicklung/dossier-15874/document-184854",
+    "/gdgs/ordnungssystem/support-und-ressourcen-departement/finanzen/rechnungsfuehrung-und-zahlungsabwicklung/dossier-15874/document-184855",
+    "/gdgs/ordnungssystem/support-und-ressourcen-departement/finanzen/rechnungsfuehrung-und-zahlungsabwicklung/dossier-15874/document-184856",
+    "/gdgs/ordnungssystem/support-und-ressourcen-departement/finanzen/rechnungsfuehrung-und-zahlungsabwicklung/dossier-15874/document-184857",
+    "/gdgs/ordnungssystem/support-und-ressourcen-departement/finanzen/rechnungsfuehrung-und-zahlungsabwicklung/dossier-15874/document-184858",
+    "/gdgs/ordnungssystem/support-und-ressourcen-departement/finanzen/rechnungsfuehrung-und-zahlungsabwicklung/dossier-15874/document-184859",
+    "/gdgs/ordnungssystem/support-und-ressourcen-departement/finanzen/rechnungsfuehrung-und-zahlungsabwicklung/dossier-15874/document-184902",
+    "/gdgs/ordnungssystem/support-und-ressourcen-departement/finanzen/rechnungsfuehrung-und-zahlungsabwicklung/dossier-18093",
+    "/gdgs/ordnungssystem/support-und-ressourcen-departement/finanzen/rechnungsfuehrung-und-zahlungsabwicklung/dossier-18093/document-184847",
+    "/gdgs/ordnungssystem/support-und-ressourcen-departement/finanzen/rechnungsfuehrung-und-zahlungsabwicklung/dossier-18093/document-184848",
+    "/gdgs/ordnungssystem/support-und-ressourcen-departement/finanzen/rechnungsfuehrung-und-zahlungsabwicklung/dossier-18093/document-184849",
+    "/gdgs/ordnungssystem/support-und-ressourcen-departement/finanzen/rechnungsfuehrung-und-zahlungsabwicklung/dossier-18093/document-184906",
+    "/gdgs/ordnungssystem/support-und-ressourcen-departement/finanzen/rechnungsfuehrung-und-zahlungsabwicklung/dossier-18093/document-184907",
+    "/gdgs/ordnungssystem/support-und-ressourcen-departement/finanzen/rechnungsfuehrung-und-zahlungsabwicklung/dossier-18093/document-184908",
+    "/gdgs/ordnungssystem/support-und-ressourcen-departement/finanzen/rechnungsfuehrung-und-zahlungsabwicklung/dossier-18093/document-184909",
+    "/gdgs/ordnungssystem/support-und-ressourcen-departement/finanzen/rechnungsfuehrung-und-zahlungsabwicklung/dossier-18093/document-184910",
+    "/gdgs/ordnungssystem/support-und-ressourcen-departement/finanzen/rechnungsfuehrung-und-zahlungsabwicklung/dossier-18093/document-184911",
+    "/gdgs/ordnungssystem/support-und-ressourcen-departement/finanzen/rechnungsfuehrung-und-zahlungsabwicklung/dossier-18093/document-184912",
+    "/gdgs/ordnungssystem/support-und-ressourcen-departement/finanzen/rechnungsfuehrung-und-zahlungsabwicklung/dossier-18093/document-184913",
+    "/gdgs/ordnungssystem/support-und-ressourcen-departement/finanzen/rechnungsfuehrung-und-zahlungsabwicklung/dossier-18093/document-184914",
+    "/gdgs/ordnungssystem/support-und-ressourcen-departement/finanzen/rechnungsfuehrung-und-zahlungsabwicklung/dossier-18093/document-184915",
+    "/gdgs/ordnungssystem/support-und-ressourcen-departement/finanzen/rechnungsfuehrung-und-zahlungsabwicklung/dossier-18093/document-184916",
+    "/gdgs/ordnungssystem/support-und-ressourcen-departement/finanzen/rechnungsfuehrung-und-zahlungsabwicklung/dossier-20251",
+    "/gdgs/ordnungssystem/support-und-ressourcen-departement/finanzen/rechnungsfuehrung-und-zahlungsabwicklung/dossier-20251/document-184961",
+    "/gdgs/ordnungssystem/support-und-ressourcen-departement/finanzen/rechnungsfuehrung-und-zahlungsabwicklung/dossier-20251/document-184962",
+    "/gdgs/ordnungssystem/support-und-ressourcen-departement/finanzen/rechnungsfuehrung-und-zahlungsabwicklung/dossier-20251/document-184963",
+    "/gdgs/ordnungssystem/support-und-ressourcen-departement/finanzen/staatsrechnung/dossier-16468/dossier-17171/dossier-18161/document-165165",
+    "/gdgs/ordnungssystem/support-und-ressourcen-departement/finanzen/staatsrechnung/dossier-18585/dossier-18656",
+    "/gdgs/ordnungssystem/support-und-ressourcen-departement/finanzen/staatsrechnung/dossier-18585/dossier-18656/dossier-20220",
+    "/gdgs/ordnungssystem/support-und-ressourcen-departement/finanzen/staatsrechnung/dossier-18585/dossier-18656/dossier-20220/document-184679",
+    "/gdgs/ordnungssystem/support-und-ressourcen-departement/finanzen/staatsrechnung/dossier-18585/dossier-18656/dossier-20220/document-184921",
+    "/gdgs/ordnungssystem/support-und-ressourcen-departement/finanzen/staatsrechnung/dossier-18585/dossier-18656/dossier-20220/document-184922",
+    "/gdgs/ordnungssystem/support-und-ressourcen-departement/finanzen/staatsrechnung/dossier-18585/dossier-18656/dossier-20220/document-184923",
+    "/gdgs/ordnungssystem/support-und-ressourcen-departement/finanzen/staatsrechnung/dossier-18585/dossier-18656/dossier-20220/document-184924",
+    "/gdgs/ordnungssystem/support-und-ressourcen-departement/finanzen/staatsrechnung/dossier-18585/dossier-18656/dossier-20220/document-184964",
+    "/gdgs/ordnungssystem/support-und-ressourcen-departement/finanzen/staatsrechnung/dossier-18585/dossier-18656/dossier-20220/document-184977",
+    "/gdgs/ordnungssystem/support-und-ressourcen-departement/finanzen/staatsrechnung/dossier-18585/dossier-18656/dossier-20220/document-184996",
+    "/gdgs/ordnungssystem/support-und-ressourcen-departement/finanzen/staatsrechnung/dossier-18585/dossier-18656/dossier-20220/document-184997",
+    "/gdgs/ordnungssystem/support-und-ressourcen-departement/finanzen/staatsrechnung/dossier-18585/dossier-18656/dossier-20220/document-184998",
+    "/gdgs/ordnungssystem/support-und-ressourcen-departement/finanzen/staatsrechnung/dossier-18585/dossier-18656/dossier-20220/document-185003",
+    "/gdgs/ordnungssystem/support-und-ressourcen-departement/finanzen/staatsrechnung/dossier-18585/dossier-18656/dossier-20220/document-185004",
+    "/gdgs/ordnungssystem/support-und-ressourcen-departement/finanzen/staatsrechnung/dossier-18585/dossier-18656/dossier-20252",
+    "/gdgs/ordnungssystem/support-und-ressourcen-departement/finanzen/staatsrechnung/dossier-18585/dossier-18656/dossier-20252/document-184965",
+    "/gdgs/ordnungssystem/support-und-ressourcen-departement/finanzen/staatsrechnung/dossier-18585/dossier-18656/dossier-20252/document-184966",
+    "/gdgs/ordnungssystem/support-und-ressourcen-departement/finanzen/staatsrechnung/dossier-18585/dossier-18656/dossier-20253",
+    "/gdgs/ordnungssystem/support-und-ressourcen-departement/finanzen/staatsrechnung/dossier-18585/dossier-18656/dossier-20253/document-184968",
+    "/gdgs/ordnungssystem/support-und-ressourcen-departement/finanzen/staatsrechnung/dossier-18585/dossier-19954/dossier-20127",
+    "/gdgs/ordnungssystem/support-und-ressourcen-departement/finanzen/staatsrechnung/dossier-18585/dossier-19954/dossier-20127/document-184597",
+    "/gdgs/ordnungssystem/support-und-ressourcen-departement/finanzen/staatsrechnung/dossier-18585/dossier-19954/dossier-20127/document-184985",
+    "/gdgs/ordnungssystem/support-und-ressourcen-departement/finanzen/staatsrechnung/dossier-18585/dossier-19954/dossier-20127/document-184986",
+    "/gdgs/ordnungssystem/support-und-ressourcen-departement/finanzen/staatsrechnung/dossier-18585/dossier-19954/dossier-20129",
+    "/gdgs/ordnungssystem/support-und-ressourcen-departement/finanzen/staatsrechnung/dossier-18585/dossier-19954/dossier-20129/document-184984",
+    "/gdgs/ordnungssystem/support-und-ressourcen-departement/finanzen/staatsrechnung/dossier-18585/dossier-19954/dossier-20129/document-184987",
+    "/gdgs/ordnungssystem/support-und-ressourcen-departement/informatik-und-telefonie/it-security/dossier-20116/document-184042",
+    "/gdgs/ordnungssystem/support-und-ressourcen-departement/informatik-und-telefonie/it-security/dossier-20116/document-184595",
+    "/gdgs/ordnungssystem/support-und-ressourcen-departement/personal/allgemeines-und-uebergreifendes/dossier-2789/dossier-19861/document-184162",
+    "/gdgs/ordnungssystem/support-und-ressourcen-departement/personal/personaladministration/personalaustritte/dossier-3780/dossier-3781",
+    "/gdgs/ordnungssystem/support-und-ressourcen-departement/personal/personaladministration/personalaustritte/dossier-3780/dossier-3781/document-184869",
+    "/gdgs/ordnungssystem/support-und-ressourcen-departement/personal/personaladministration/personalaustritte/dossier-3780/dossier-3784",
+    "/gdgs/ordnungssystem/support-und-ressourcen-departement/personal/personaladministration/personalaustritte/dossier-3780/dossier-3784/document-184868",
+    "/gdgs/ordnungssystem/support-und-ressourcen-departement/personal/personaladministration/personalbetreuung/dossier-3482/dossier-19791",
+    "/gdgs/ordnungssystem/support-und-ressourcen-departement/personal/personaladministration/personalbetreuung/dossier-3482/dossier-19791/document-184973",
+    "/gdgs/ordnungssystem/support-und-ressourcen-departement/personal/personaladministration/personalbetreuung/dossier-3482/dossier-19791/document-184974",
+    "/gdgs/ordnungssystem/support-und-ressourcen-departement/personal/personaladministration/personalbetreuung/dossier-3482/dossier-19792",
+    "/gdgs/ordnungssystem/support-und-ressourcen-departement/personal/personaladministration/personalbetreuung/dossier-3482/dossier-19792/document-184972",
+    "/gdgs/ordnungssystem/support-und-ressourcen-departement/personal/personaladministration/personalbetreuung/dossier-3523/dossier-3553",
+    "/gdgs/ordnungssystem/support-und-ressourcen-departement/personal/personaladministration/personalbetreuung/dossier-3523/dossier-3553/document-184936",
+    "/gdgs/ordnungssystem/support-und-ressourcen-departement/personal/personaladministration/personalbetreuung/dossier-3558/dossier-3582",
+    "/gdgs/ordnungssystem/support-und-ressourcen-departement/personal/personaladministration/personalbetreuung/dossier-3558/dossier-3582/document-184585",
+    "/gdgs/ordnungssystem/support-und-ressourcen-departement/personal/personaladministration/personalbetreuung/dossier-3558/dossier-3582/document-184867",
+    "/gdgs/ordnungssystem/support-und-ressourcen-departement/personal/personaladministration/personalentloehnung/dossier-10904/dossier-12270/document-112638",
+    "/gdgs/ordnungssystem/support-und-ressourcen-departement/personal/personaladministration/personalentloehnung/dossier-14557/document-184586",
+    "/gdgs/ordnungssystem/support-und-ressourcen-departement/personal/personaladministration/personalentwicklung/dossier-3603",
+    "/gdgs/ordnungssystem/support-und-ressourcen-departement/personal/personaladministration/personalentwicklung/dossier-3603/document-184956",
+    "/gdgs/ordnungssystem/support-und-ressourcen-departement/personal/personaladministration/personalgewinnung/dossier-17918/dossier-17938/dossier-20016",
+    "/gdgs/ordnungssystem/support-und-ressourcen-departement/personal/personaladministration/personalgewinnung/dossier-17918/dossier-17938/dossier-20016/document-173150",
+    "/gdgs/ordnungssystem/support-und-ressourcen-departement/personal/personaladministration/personalgewinnung/dossier-20101/dossier-20143/dossier-20144",
+    "/gdgs/ordnungssystem/support-und-ressourcen-departement/personal/personaladministration/personalgewinnung/dossier-20101/dossier-20143/dossier-20144/document-184886",
+    "/gdgs/ordnungssystem/support-und-ressourcen-departement/personal/personaladministration/personalgewinnung/dossier-20101/dossier-20143/dossier-20144/document-184887",
+    "/gdgs/ordnungssystem/support-und-ressourcen-departement/personal/personaladministration/personalgewinnung/dossier-20101/dossier-20143/dossier-20144/document-184888",
+    "/gdgs/ordnungssystem/support-und-ressourcen-departement/personal/personaladministration/personalgewinnung/dossier-20101/dossier-20143/dossier-20144/document-185005",
+    "/gdgs/ordnungssystem/support-und-ressourcen-departement/personal/personaladministration/personalgewinnung/dossier-3220/dossier-20110/document-184184",
+    "/gdgs/ordnungssystem/support-und-ressourcen-departement/politische-planung/geschaeftsbericht/dossier-19809/dossier-19938/document-183934",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/beratung-und-auskuenfte/kundendienstleistungen-kantonsapotheke/dossier-19437/dossier-19821",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/beratung-und-auskuenfte/kundendienstleistungen-kantonsapotheke/dossier-19437/dossier-19821/document-184851",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/beratung-und-auskuenfte/kundendienstleistungen-kantonsapotheke/dossier-19437/dossier-19821/document-184897",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/beratung-und-auskuenfte/kundendienstleistungen-kantonsapotheke/dossier-19437/dossier-19821/document-184905",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/beratung-und-auskuenfte/kundendienstleistungen-kantonsapotheke/dossier-19437/dossier-19821/document-184975",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/beratung-und-auskuenfte/kundendienstleistungen-kantonsapotheke/dossier-19437/dossier-19821/document-184976",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/beratung-und-auskuenfte/kundendienstleistungen-kantonsapotheke/dossier-19437/dossier-19821/dossier-20098",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/beratung-und-auskuenfte/kundendienstleistungen-kantonsapotheke/dossier-19437/dossier-19821/dossier-20098/document-184978",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/beratung-und-auskuenfte/weitere-beratungen-und-auskuenfte/dossier-17024/dossier-20053",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/beratung-und-auskuenfte/weitere-beratungen-und-auskuenfte/dossier-17024/dossier-20053/document-184866",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/bewilligungen-kantonsapotheke/aerztliche-privatapotheken/dossier-10805/dossier-19273",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/bewilligungen-kantonsapotheke/aerztliche-privatapotheken/dossier-10805/dossier-19273/document-184904",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/bewilligungen-kantonsapotheke/aerztliche-privatapotheken/dossier-15787/dossier-19846",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/bewilligungen-kantonsapotheke/aerztliche-privatapotheken/dossier-15787/dossier-19846/document-184891",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/bewilligungen-kantonsapotheke/aerztliche-privatapotheken/dossier-19275/dossier-19415",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/bewilligungen-kantonsapotheke/aerztliche-privatapotheken/dossier-19275/dossier-19415/document-184928",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/bewilligungen-kantonsapotheke/aerztliche-privatapotheken/dossier-19296/dossier-20001",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/bewilligungen-kantonsapotheke/aerztliche-privatapotheken/dossier-19296/dossier-20001/document-184979",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/bewilligungen-kantonsapotheke/aerztliche-privatapotheken/dossier-19698/dossier-19700",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/bewilligungen-kantonsapotheke/aerztliche-privatapotheken/dossier-19698/dossier-19700/document-184861",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/bewilligungen-kantonsapotheke/aerztliche-privatapotheken/dossier-19698/dossier-19700/document-184882",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/bewilligungen-kantonsapotheke/aerztliche-privatapotheken/dossier-19710/dossier-19711",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/bewilligungen-kantonsapotheke/aerztliche-privatapotheken/dossier-19710/dossier-19711/document-184927",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/bewilligungen-kantonsapotheke/aerztliche-privatapotheken/dossier-19781/dossier-19782",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/bewilligungen-kantonsapotheke/aerztliche-privatapotheken/dossier-19781/dossier-19782/document-184926",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/bewilligungen-kantonsapotheke/aerztliche-privatapotheken/dossier-19783/dossier-19784",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/bewilligungen-kantonsapotheke/aerztliche-privatapotheken/dossier-19783/dossier-19784/document-184925",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/bewilligungen-kantonsapotheke/aerztliche-privatapotheken/dossier-19812/dossier-19813",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/bewilligungen-kantonsapotheke/aerztliche-privatapotheken/dossier-19812/dossier-19813/document-184903",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/bewilligungen-kantonsapotheke/aerztliche-privatapotheken/dossier-19884",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/bewilligungen-kantonsapotheke/aerztliche-privatapotheken/dossier-19884/document-184879",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/bewilligungen-kantonsapotheke/aerztliche-privatapotheken/dossier-19884/dossier-19885",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/bewilligungen-kantonsapotheke/aerztliche-privatapotheken/dossier-19884/dossier-19885/document-184938",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/bewilligungen-kantonsapotheke/aerztliche-privatapotheken/dossier-19884/dossier-19885/document-184941",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/bewilligungen-kantonsapotheke/aerztliche-privatapotheken/dossier-19884/dossier-19885/document-184943",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/bewilligungen-kantonsapotheke/aerztliche-privatapotheken/dossier-19884/dossier-19885/document-184944",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/bewilligungen-kantonsapotheke/aerztliche-privatapotheken/dossier-19884/dossier-19885/document-184946",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/bewilligungen-kantonsapotheke/apotheken/dossier-10358",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/bewilligungen-kantonsapotheke/apotheken/dossier-10358/dossier-20265",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/bewilligungen-kantonsapotheke/apotheken/dossier-10358/dossier-20265/document-184982",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/bewilligungen-kantonsapotheke/apotheken/dossier-19862",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/bewilligungen-kantonsapotheke/apotheken/dossier-19862/dossier-20242",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/bewilligungen-kantonsapotheke/apotheken/dossier-19862/dossier-20242/document-184893",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/bewilligungen-kantonsapotheke/apotheken/dossier-19862/dossier-20242/document-184895",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/bewilligungen-kantonsapotheke/apotheken/dossier-5754/dossier-12858",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/bewilligungen-kantonsapotheke/apotheken/dossier-5754/dossier-12858/document-184917",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/bewilligungen-kantonsapotheke/drogerien/dossier-13693",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/bewilligungen-kantonsapotheke/drogerien/dossier-13693/dossier-20240",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/bewilligungen-kantonsapotheke/drogerien/dossier-13693/dossier-20240/document-184865",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/bewilligungen-kantonsapotheke/drogerien/dossier-13693/dossier-20240/document-184898",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/bewilligungen-kantonsapotheke/drogerien/dossier-13693/dossier-20240/document-184899",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/bewilligungen-kantonsapotheke/drogerien/dossier-18685",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/bewilligungen-kantonsapotheke/drogerien/dossier-18685/dossier-20239",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/bewilligungen-kantonsapotheke/drogerien/dossier-18685/dossier-20239/document-184864",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/bewilligungen-kantonsapotheke/drogerien/dossier-18685/dossier-20239/document-184951",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/bewilligungen-kantonsapotheke/drogerien/dossier-18685/dossier-20239/document-184952",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/bewilligungen-kantonsapotheke/drogerien/dossier-18685/dossier-20239/document-184953",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/bewilligungen-kantonsapotheke/drogerien/dossier-18685/dossier-20239/document-184954",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/bewilligungen-kantonsapotheke/drogerien/dossier-18685/dossier-20239/document-184955",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/bewilligungen-kantonsapotheke/drogerien/dossier-18685/dossier-20239/document-184959",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/bewilligungen-kantonsapotheke/drogerien/dossier-18685/dossier-20239/document-184960",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/bewilligungen-kantonsapotheke/drogerien/dossier-18685/dossier-20250",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/bewilligungen-kantonsapotheke/drogerien/dossier-18685/dossier-20260",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/bewilligungen-kantonsapotheke/swissmedic/dossier-10278",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/bewilligungen-kantonsapotheke/swissmedic/dossier-10278/document-184873",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/bewilligungen-kantonsapotheke/swissmedic/dossier-10278/document-184874",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/bewilligungen-kantonsapotheke/swissmedic/dossier-14970",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/bewilligungen-kantonsapotheke/swissmedic/dossier-14970/document-184875",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/bewilligungen-kantonsapotheke/swissmedic/dossier-16076",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/bewilligungen-kantonsapotheke/swissmedic/dossier-16076/document-184876",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/bewilligungen-kantonsapotheke/swissmedic/dossier-16076/document-184878",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/bewilligungen-kantonsapotheke/swissmedic/dossier-18899",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/bewilligungen-kantonsapotheke/swissmedic/dossier-18899/document-184877",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/bewilligungen-kantonsapotheke/swissmedic/dossier-19630",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/bewilligungen-kantonsapotheke/swissmedic/dossier-19630/document-184872",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/bewilligungen-kantonsapotheke/swissmedic/dossier-19797",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/bewilligungen-kantonsapotheke/swissmedic/dossier-19797/document-181003",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/bewilligungen-kantonsapotheke/swissmedic/dossier-19797/document-181463",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/bewilligungen-kantonsapotheke/swissmedic/dossier-19797/document-184852",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/bewilligungen-kantonsapotheke/swissmedic/dossier-19797/document-184894",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/bewilligungen-kantonsapotheke/swissmedic/dossier-19797/document-184948",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/bewilligungen-kantonsapotheke/zahnaerztliche-privatapotheken/dossier-18465",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/bewilligungen-kantonsapotheke/zahnaerztliche-privatapotheken/dossier-18465/dossier-20262",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/bewilligungen-spitex/dossier-17585/document-161773",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/weitere-bewilligungen",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/weitere-bewilligungen/dossier-18144",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/weitere-bewilligungen/dossier-18144/document-184862",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/weitere-bewilligungen/dossier-18144/document-184883",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/weitere-bewilligungen/dossier-18144/document-184896",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/weitere-bewilligungen/dossier-18144/document-184957",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/weitere-bewilligungen/dossier-18144/document-184958",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/weitere-bewilligungen/dossier-18144/document-184990",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/weitere-bewilligungen/dossier-18275",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/weitere-bewilligungen/dossier-18275/document-170472",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/weitere-bewilligungen/dossier-18275/document-184822",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/weitere-bewilligungen/dossier-18275/document-184841",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/weitere-bewilligungen/dossier-18275/document-184842",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/weitere-bewilligungen/dossier-18275/document-184843",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/weitere-bewilligungen/dossier-18275/document-184844",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/weitere-bewilligungen/dossier-18275/document-184845",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/weitere-bewilligungen/dossier-18275/document-184846",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/weitere-bewilligungen/dossier-18275/document-184850",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/weitere-bewilligungen/dossier-18275/document-184871",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/weitere-bewilligungen/dossier-18275/document-184889",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/weitere-bewilligungen/dossier-18275/document-184890",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/weitere-bewilligungen/dossier-18275/document-184901",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/weitere-bewilligungen/dossier-18275/document-184918",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/weitere-bewilligungen/dossier-18275/document-184967",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/weitere-bewilligungen/dossier-18275/document-184969",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/weitere-bewilligungen/dossier-18275/document-184971",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/weitere-bewilligungen/dossier-18275/document-184983",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/weitere-bewilligungen/dossier-18299",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/weitere-bewilligungen/dossier-18299/document-184937",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/weitere-bewilligungen/dossier-18299/document-184945",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/weitere-bewilligungen/dossier-20254",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/bewilligungswesen-und-aufsicht/weitere-bewilligungen/dossier-20254/document-184970",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/pflege-und-entwicklung/ausbildungsverpflichtungen/dossier-19091/dossier-19096/document-183988",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/rechtspflege/rechtsauskuenfte/dossier-18087/dossier-18121",
+    "/gdgs/ordnungssystem/weitere-kernaufgaben/rechtspflege/rechtsauskuenfte/dossier-18087/dossier-18121/document-184920",
+    "/gdgs/ordnungssystem/zusammenarbeit-mit-dritten/gremien/dossier-18003",
+    "/gdgs/ordnungssystem/zusammenarbeit-mit-dritten/gremien/dossier-18003/dossier-20241",
+    "/gdgs/ordnungssystem/zusammenarbeit-mit-dritten/gremien/dossier-18003/dossier-20241/document-184870",
+    "/gdgs/ordnungssystem/zusammenarbeit-mit-dritten/gremien/dossier-20119/dossier-20231/document-184761",
+    "/gdgs/ordnungssystem/zusammenarbeit-mit-dritten/projekte/dossier-20179",
+    "/gdgs/ordnungssystem/zusammenarbeit-mit-dritten/projekte/dossier-20179/document-184860",
+    "/gdgs/ordnungssystem/zusammenarbeit-mit-dritten/projekte/dossier-20179/dossier-20180",
+    "/gdgs/ordnungssystem/zusammenarbeit-mit-dritten/projekte/dossier-20179/dossier-20180/document-184302",
+    "/gdgs/ordnungssystem/zusammenarbeit-mit-dritten/projekte/dossier-20179/dossier-20180/document-184315",
+    "/gdgs/ordnungssystem/zusammenarbeit-mit-dritten/projekte/dossier-20179/dossier-20180/document-184880",
+]
+
+EXTRACTION_PATH = '/home/zope/01-gever-gdgs-prod/extracted_documents'
+
+
+def mkdir_p(path):
+    try:
+        os.makedirs(path)
+    except OSError as exc:  # Python >2.5
+        if exc.errno == errno.EEXIST and os.path.isdir(path):
+            pass
+        else:
+            raise
+
+
+class DocumentsExctractor(object):
+
+    def __init__(self, portal, options):
+        self.portal = portal
+        self.options = options
+        self.request = getRequest()
+        alsoProvides(self.request, IOpengeverBaseLayer)
+        mkdir_p(EXTRACTION_PATH)
+
+    def run(self):
+        for path in CHANGED_OBJS:
+            obj = self.portal.unrestrictedTraverse(path)
+            portal_type = obj.portal_type
+
+            print('Getting metadata for %s' % path)
+            uid = obj.UID()
+            metadata = self.get_metadata(obj)
+            metadata_filename = '%s.json' % uid
+
+            namedfile = None
+            if portal_type == 'opengever.document.document':
+                namedfile = aq_base(obj).file
+            elif portal_type == 'ftw.mail.mail':
+                namedfile = aq_base(obj).message
+            else:
+                # No blob to extract for these types
+                assert portal_type in (
+                    'opengever.dossier.businesscasedossier',
+                    'opengever.task.task',
+                    'opengever.repository.repositoryfolder',
+                )
+
+            if namedfile:
+                filename = namedfile.filename
+                data = namedfile.data
+                content_type = namedfile.contentType
+                zodb_blob_path = namedfile._blob.committed()
+                claimed_length = len(data)
+                checksum = hashlib.md5(data).hexdigest()
+
+                blob_fn = '%s.blob' % uid
+                extracted_blob_path = pjoin(EXTRACTION_PATH, blob_fn)
+                shutil.copy2(src=zodb_blob_path, dst=extracted_blob_path)
+
+                metadata.update({
+                    '_blob_filename': filename,
+                    '_blob_content_type': content_type,
+                    '_blob_md5_checksum': checksum,
+                    '_blob_path': extracted_blob_path,
+                    '_blob_claimed_length': claimed_length,
+                })
+
+            metadata_path = pjoin(EXTRACTION_PATH, metadata_filename)
+            with open(metadata_path, 'w') as outfile:
+                json.dump(metadata, outfile, indent=4)
+
+    def get_metadata(self, obj):
+        serializer = queryMultiAdapter((obj, self.request), ISerializeToJson)
+        data = serializer()
+        return data
+
+
+if __name__ == '__main__':
+    transaction.doom()
+    app = setup_app()
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-s', dest='site_root', default=None,
+                        help='Absolute path to the Plone site')
+
+    options = parser.parse_args(sys.argv[3:])
+
+    plone = setup_plone(app, options)
+
+    extractor = DocumentsExctractor(plone, options)
+    extractor.run()

--- a/opengever/maintenance/scripts/find_orphaned_tasks.py
+++ b/opengever/maintenance/scripts/find_orphaned_tasks.py
@@ -1,0 +1,106 @@
+from opengever.base.interfaces import IOpengeverBaseLayer
+from opengever.base.model import create_session
+from opengever.globalindex.model.task import Task
+from opengever.maintenance.debughelpers import setup_app
+from opengever.maintenance.debughelpers import setup_plone
+from opengever.task.task import ITask
+from plone import api
+from zope.component import getUtility
+from zope.globalrequest import getRequest
+from zope.interface import alsoProvides
+from zope.intid import IIntIds
+import argparse
+import sys
+
+
+class OrphanedTaskFinder(object):
+
+    def __init__(self, portal, options):
+        self.portal = portal
+        self.options = options
+        self.request = getRequest()
+        alsoProvides(self.request, IOpengeverBaseLayer)
+        self._orphaned_plone_tasks = None
+
+    def find_local_tasks_by_title(self, title):
+        candidates = [t for t in self._orphaned_plone_tasks if t.title == title]
+        return candidates
+
+    def run(self):
+        intids = getUtility(IIntIds)
+        session = create_session()
+
+        # Check Plone tasks first
+        orphaned_plone_tasks = []
+        catalog = api.portal.get_tool('portal_catalog')
+        brains = catalog(object_provides=ITask.__identifier__)
+        for brain in brains:
+            plone_task = brain.getObject()
+            plone_int_id = intids.queryId(plone_task)
+            if plone_int_id is None:
+                print('Task %r is missing intid' % plone_task)
+            sql_task = plone_task.get_sql_object()
+            if not sql_task:
+                orphaned_plone_tasks.append(plone_task)
+
+        self._orphaned_plone_tasks = orphaned_plone_tasks
+        print('\nOrphaned Plone Tasks: %r' % len(orphaned_plone_tasks))
+        print('=' * 80)
+        for task in orphaned_plone_tasks:
+            print('%r (Title: %r)' % (task, task.title))
+
+        # Check SQL tasks
+        orphaned_by_intid = {}
+        orphaned_by_path = {}
+
+        tasks = session.query(Task).filter_by(admin_unit_id='gdgs')
+        for task in tasks:
+            sql_int_id = task.int_id
+            plone_obj = intids.queryObject(sql_int_id)
+            if plone_obj is None:
+                orphaned_by_intid[sql_int_id] = task
+
+            relative_path = task.physical_path.encode('utf-8')
+            try:
+                plone_obj = self.portal.unrestrictedTraverse(relative_path)
+            except KeyError:
+                orphaned_by_path[relative_path] = task
+
+        print('\nOrphaned by IntId: %r' % len(orphaned_by_intid))
+        print('=' * 80)
+        print
+        for task in orphaned_by_intid.values():
+            print('Task ID: %r (IntId: %r Title: %r)' % (task.id, task.int_id, task.title))
+            candidates = self.find_local_tasks_by_title(task.title)
+            for cand in candidates:
+                path = '/'.join(cand.getPhysicalPath())
+                candidate_intid = intids.queryId(cand)
+                print('    Candidate: %s (IntId: %r)' % (path, candidate_intid))
+            print
+
+        print('\nOrphaned by path: %r' % len(orphaned_by_path))
+        print('=' * 80)
+        print
+        for task in orphaned_by_path.values():
+            print('Task ID %r (Path: %r Title: %r)' % (task.id, task.physical_path, task.title))
+            candidates = self.find_local_tasks_by_title(task.title)
+            for cand in candidates:
+                path = '/'.join(cand.getPhysicalPath())
+                candidate_intid = intids.queryId(cand)
+                print('    Candidate: %s (IntId: %r)' % (path, candidate_intid))
+            print
+
+
+if __name__ == '__main__':
+    app = setup_app()
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-s', dest='site_root', default=None,
+                        help='Absolute path to the Plone site')
+
+    options = parser.parse_args(sys.argv[3:])
+
+    plone = setup_plone(app, options)
+
+    finder = OrphanedTaskFinder(plone, options)
+    finder.run()

--- a/opengever/maintenance/scripts/import_extracted_gdgs_documents.py
+++ b/opengever/maintenance/scripts/import_extracted_gdgs_documents.py
@@ -1,0 +1,247 @@
+from Acquisition import aq_base
+from Acquisition.interfaces import IAcquirer
+from collective.taskqueue.interfaces import ITaskQueue
+from collective.taskqueue.interfaces import ITaskQueueLayer
+from collective.taskqueue.taskqueue import LocalVolatileTaskQueue
+from opengever.base.interfaces import IOpengeverBaseLayer
+from opengever.document.versioner import Versioner
+from opengever.maintenance.debughelpers import setup_app
+from opengever.maintenance.debughelpers import setup_plone
+from operator import itemgetter
+from os.path import join as pjoin
+from plone.api.env import adopt_user
+from plone.namedfile.file import NamedBlobFile
+from plone.restapi.exceptions import DeserializationError
+from plone.restapi.interfaces import IDeserializeFromJson
+from plone.restapi.services.content.utils import add
+from plone.restapi.services.content.utils import create
+from plone.subrequest import subrequest
+from Products.CMFPlone.utils import safe_hasattr
+from zExceptions import BadRequest
+from zExceptions import Unauthorized
+from zope.component import provideUtility
+from zope.component import queryMultiAdapter
+from zope.event import notify
+from zope.globalrequest import getRequest
+from zope.interface import alsoProvides
+from zope.interface import noLongerProvides
+from zope.lifecycleevent import ObjectCreatedEvent
+import argparse
+import json
+import os
+import sys
+import transaction
+
+
+EXTRACTION_PATH = '/home/zope/03-gever-gdgs/extracted_documents'
+
+
+CREATED_OBJS_BY_OLD_PATH = {}
+
+
+def create_and_add(container, type_, data, id_=None, title=None):
+    try:
+        obj = create(container, type_, id_=id_, title=title)
+    except Unauthorized:
+        raise
+    except BadRequest:
+        raise
+
+    # Acquisition wrap temporarily to satisfy things like vocabularies
+    # depending on tools
+    temporarily_wrapped = False
+    if IAcquirer.providedBy(obj) and not safe_hasattr(obj, "aq_base"):
+        obj = obj.__of__(container)
+        temporarily_wrapped = True
+
+    # Update fields
+    deserializer = queryMultiAdapter((obj, getRequest()), IDeserializeFromJson)
+    if deserializer is None:
+        raise Exception('No deserializer found')
+
+    try:
+        deserializer(validate_all=True, data=data, create=True)
+    except DeserializationError:
+        raise
+
+    if temporarily_wrapped:
+        obj = aq_base(obj)
+
+    if not getattr(deserializer, "notifies_create", False):
+        notify(ObjectCreatedEvent(obj))
+
+    obj = add(container, obj, rename=not bool(id_))
+    return obj
+
+
+class ObjectImporter(object):
+
+    def __init__(self, portal, options):
+        self.portal = portal
+        self.options = options
+
+        self.request = getRequest()
+        self.portal.setupCurrentSkin()
+        alsoProvides(self.request, IOpengeverBaseLayer)
+        self.missing_parent_count = 0
+        self._task_queue = self.setup_task_queue()
+
+    def setup_task_queue(self):
+        task_queue = LocalVolatileTaskQueue()
+        provideUtility(task_queue, ITaskQueue, name='default')
+        return task_queue
+
+    def run(self):
+        all_object_metadata = []
+
+        # Load all metadata
+        for fn in os.listdir(EXTRACTION_PATH):
+            if not fn.endswith('.json'):
+                continue
+            metadata_path = pjoin(EXTRACTION_PATH, fn)
+            metadata = json.load(open(metadata_path))
+            all_object_metadata.append(metadata)
+
+        self.all_paths = [item['relative_path'] for item in all_object_metadata]
+
+        for item in sorted(all_object_metadata, key=itemgetter('relative_path')):
+            path = item['relative_path'].encode('utf-8')
+            portal_type = item['@type']
+            path = item['relative_path'].encode('utf-8')
+            # id_ = path.split('/')[-1]
+
+            try:
+                existing_obj = self.portal.unrestrictedTraverse(path)
+                self.update_object(existing_obj, item)
+            except KeyError:
+                username = item.get('creator', {}).get('identifier', 'zopemaster')
+                portal_type = item['@type']
+                if portal_type == 'opengever.task.task':
+                    self.create_object(path, portal_type, item)
+                else:
+                    with adopt_user(username=username):
+                        self.create_object(path, portal_type, item)
+
+        self.process_task_queue()
+        print('Missing parents: %s' % self.missing_parent_count)
+
+    def update_object(self, existing_obj, item):
+        portal_type = item['@type']
+
+        # We don't update other types of objects
+        if portal_type == 'opengever.document.document':
+
+            # Set file
+            blob_path = pjoin(EXTRACTION_PATH, item['_blob_path'].split('/')[-1])
+            filename = item['_blob_filename']
+            content_type = item['_blob_content_type']
+            data = open(blob_path, 'rb').read()
+            existing_obj.file = NamedBlobFile(data=data, filename=filename, contentType=content_type)
+            Versioner(existing_obj).create_version('Restored from backup')
+            print('Updated object %r' % existing_obj)
+
+    def create_object(self, old_path, portal_type, item):
+        parent_path = '/'.join(old_path.split('/')[:-1])
+
+        parent = CREATED_OBJS_BY_OLD_PATH.get(parent_path)
+        if parent is None:
+            try:
+                parent = self.portal.unrestrictedTraverse(parent_path)
+            except KeyError:
+                if parent_path not in self.all_paths:
+                    print('Parent does not exist for %s' % old_path)
+                    self.missing_parent_count += 1
+                    return
+
+        title = item.get('title', item.get('title_de'))
+
+        if portal_type == 'opengever.dossier.businesscasedossier':
+            data = item.copy()
+            data.pop('relatedDossier', None)
+            created_obj = create_and_add(parent, portal_type, data, title=title)
+
+        elif portal_type == 'opengever.document.document':
+            data = item.copy()
+            created_obj = create_and_add(parent, portal_type, data, title=title)
+
+            # Set file
+            blob_path = pjoin(EXTRACTION_PATH, item['_blob_path'].split('/')[-1])
+            filename = item['_blob_filename']
+            content_type = item['_blob_content_type']
+            data = open(blob_path, 'rb').read()
+
+            created_obj.file = NamedBlobFile(data=data, filename=filename, contentType=content_type)
+            Versioner(created_obj).create_initial_version()
+
+        elif portal_type == 'ftw.mail.mail':
+            data = item.copy()
+            # title = u'tmp'
+            try:
+                created_obj = create_and_add(parent, portal_type, data, title=title)
+            except Exception as exc:
+                print('Failed to create object at %s' % old_path)
+                print(exc)
+                return
+            # created_obj.sync_title_and_filename()
+
+            # Set file
+            blob_path = pjoin(EXTRACTION_PATH, item['_blob_path'].split('/')[-1])
+            filename = item['_blob_filename']
+            content_type = item['_blob_content_type']
+            data = open(blob_path, 'rb').read()
+            created_obj.message = NamedBlobFile(data=data, filename=filename, contentType=content_type)
+            # no intial version needed for mails
+
+        elif portal_type == 'opengever.task.task':
+            data = item.copy()
+            data.pop('relatedItems', None)
+            created_obj = create_and_add(parent, portal_type, data, title=title)
+
+        else:
+            raise AssertionError("Unexpected type %s" % portal_type)
+
+        CREATED_OBJS_BY_OLD_PATH[old_path] = created_obj
+        print('Created %r' % created_obj)
+
+    def process_task_queue(self):
+        queue = self._task_queue.queue
+
+        print('Processing %d task queue jobs...' % queue.qsize())
+        request = getRequest()
+        alsoProvides(request, ITaskQueueLayer)
+
+        while not queue.empty():
+            job = queue.get()
+
+            # Process job using plone.subrequest
+            response = subrequest(job['url'])
+            assert response.status == 200
+
+        noLongerProvides(request, ITaskQueueLayer)
+        print('All task queue jobs processed.')
+
+
+if __name__ == '__main__':
+    app = setup_app()
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-s', dest='site_root', default=None,
+                        help='Absolute path to the Plone site')
+    parser.add_argument("-n", "--dry-run", action="store_true",
+                        help="Dry run")
+
+    options = parser.parse_args(sys.argv[3:])
+
+    if options.dry_run:
+        print("DRY RUN")
+        transaction.doom()
+
+    plone = setup_plone(app, options)
+
+    importer = ObjectImporter(plone, options)
+    importer.run()
+
+    if not options.dry_run:
+        print('Committing transaction...')
+        transaction.commit()
+        print('Done.')


### PR DESCRIPTION
These scripts were used to recover data (Documents, Dossiers, ...) that was created/modified between the most recent Data.fs backup from Abraxas (2023-01-23 04:00) and the point when we set the deployment to read-only mode (2023-01-25 15:20).

Object metadata and blobs were extracted with the extraction script from the corrupted Database, and re-imported on top of the restored Abraxas Backup using the import script.

The script to find orphaned tasks was needed because when those tasks for GDGS were recreated on a staging deployment, the got written to an OGDS that wasn't reconciled back into the PROD OGDS (we just copied over Data.fs and Solr from the staging deployment back to PROD).

For 
https://4teamwork.atlassian.net/browse/CA-5305
https://4teamwork.atlassian.net/browse/CA-5290
https://4teamwork.atlassian.net/browse/CA-5281 