### PR TITLE
Improve script to fix reference number mappings on repository folders.

### DIFF
--- a/opengever/maintenance/scripts/fix_refnum_mappings.py
+++ b/opengever/maintenance/scripts/fix_refnum_mappings.py
@@ -99,14 +99,39 @@ def fix_refnum_mappings(plone):
     print 'Updated a total of {} mappings'.format(n_updated)
 
 
+def reindex_repository_folders(plone):
+    catalog = api.portal.get_tool('portal_catalog')
+    brains = catalog.unrestrictedSearchResults(
+        portal_type=['opengever.repository.repositoryroot',
+                     'opengever.repository.repositoryfolder']
+    )
+
+    n_tot = len(brains)
+    logger.info('\n\nReindexing {} reference numbers\n'.format(n_tot))
+
+    for i, brain in enumerate(brains, 1):
+        if i % 100 == 0:
+            logger.info(u'Done {} / {}'.format(i, n_tot))
+        obj = brain.getObject()
+        obj.reindexObject()
+
+    print 'Reindexed {} reference numbers'.format(n_tot)
+
+
 def main():
     parser = setup_option_parser()
     parser.add_option("-n", "--dry-run", action="store_true",
                       dest="dryrun", default=False)
+    parser.add_option("-r", "--reindex", action="store_true",
+                      dest="reindex", default=False)
     (options, args) = parser.parse_args()
 
     plone = setup_plone(setup_app())
     fix_refnum_mappings(plone)
+
+    if options.reindex:
+        logger.info("reindexing...")
+        reindex_repository_folders(plone)
 
     if not options.dryrun:
         logger.info("Committing...")

--- a/opengever/maintenance/scripts/fix_refnum_mappings.py
+++ b/opengever/maintenance/scripts/fix_refnum_mappings.py
@@ -34,6 +34,13 @@ def mapping_needs_update(obj):
         if not prefix_mapping.get(intid) == IReferenceNumber(child).get_local_number():
             return True
 
+    # If there are intids in the prefix mapping that are not children,
+    # they should be of objects that were deleted
+    for intid in set(prefix_mapping.keys()) - children_intids:
+        obj = intids.queryObject(intid)
+        if obj is not None:
+            return True
+
     mapping_intids = set()
     for intid in ref_adapter.get_child_mapping().values():
         # if the object has been deleted, then it can remain in the mapping


### PR DESCRIPTION
When a repofolder gets moved (how that happens is still unclear), then we are left with a valid intid in the mapping, which will lead to the reference prefix [still being considered as used](https://github.com/4teamwork/opengever.core/blob/master/opengever/base/adapters.py#L192-L198). Here we update the script cleaning up the mappings to cover that case.

As we currently also have a bug that reference numbers of repofolders do not get indexed properly when the prefix of the parent is changed (https://4teamwork.atlassian.net/browse/CA-4553), and as issues leading to the problems fixed by this script might also have led to incorrect indexing, I also add an option to reindex all repository folders. This makes a rather big transaction which might be slow to commit.

For https://4teamwork.atlassian.net/browse/CA-5497