### PR TITLE
Remove test files for versions < 2021.19.

### DIFF
--- a/test-og-2019.5.x.cfg
+++ b/test-og-2019.5.x.cfg
@@ -1,9 +1,0 @@
-[buildout]
-extends =
-    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
-    https://raw.githubusercontent.com/4teamwork/opengever.core/2019.5.1/versions.cfg
-    base-testing.cfg
-
-
-[versions]
-setuptools = 44.1.1

--- a/test-og-2019.6.x.cfg
+++ b/test-og-2019.6.x.cfg
@@ -1,8 +1,0 @@
-[buildout]
-extends =
-    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
-    https://raw.githubusercontent.com/4teamwork/opengever.core/2019.6.4/versions.cfg
-    base-testing.cfg
-
-[versions]
-setuptools = 44.1.1

--- a/test-og-2020.10.x.cfg
+++ b/test-og-2020.10.x.cfg
@@ -1,9 +1,0 @@
-[buildout]
-extends =
-    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
-    https://raw.githubusercontent.com/4teamwork/opengever.core/2020.10.0/versions.cfg
-    base-testing.cfg
-
-[test]
-eggs +=
-    unittest2

--- a/test-og-2020.11.x.cfg
+++ b/test-og-2020.11.x.cfg
@@ -1,9 +1,0 @@
-[buildout]
-extends =
-    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
-    https://raw.githubusercontent.com/4teamwork/opengever.core/2020.11.0/versions.cfg
-    base-testing.cfg
-
-[test]
-eggs +=
-    unittest2

--- a/test-og-2020.13.x.cfg
+++ b/test-og-2020.13.x.cfg
@@ -1,9 +1,0 @@
-[buildout]
-extends =
-    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
-    https://raw.githubusercontent.com/4teamwork/opengever.core/2020.13.0/versions.cfg
-    base-testing.cfg
-
-[test]
-eggs +=
-    unittest2

--- a/test-og-2020.14.x.cfg
+++ b/test-og-2020.14.x.cfg
@@ -1,9 +1,0 @@
-[buildout]
-extends =
-    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
-    https://raw.githubusercontent.com/4teamwork/opengever.core/2020.14.5/versions.cfg
-    base-testing.cfg
-
-[test]
-eggs +=
-    unittest2

--- a/test-og-2020.15.x.cfg
+++ b/test-og-2020.15.x.cfg
@@ -1,9 +1,0 @@
-[buildout]
-extends =
-    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
-    https://raw.githubusercontent.com/4teamwork/opengever.core/2020.15.1/versions.cfg
-    base-testing.cfg
-
-[test]
-eggs +=
-    unittest2

--- a/test-og-2020.9.x.cfg
+++ b/test-og-2020.9.x.cfg
@@ -1,9 +1,0 @@
-[buildout]
-extends =
-    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
-    https://raw.githubusercontent.com/4teamwork/opengever.core/2020.9.0/versions.cfg
-    base-testing.cfg
-
-[test]
-eggs +=
-    unittest2

--- a/test-og-2021.10.x.cfg
+++ b/test-og-2021.10.x.cfg
@@ -1,9 +1,0 @@
-[buildout]
-extends =
-    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
-    https://raw.githubusercontent.com/4teamwork/opengever.core/2021.10.0/versions.cfg
-    base-testing.cfg
-
-[test]
-eggs +=
-    unittest2

--- a/test-og-2021.11.x.cfg
+++ b/test-og-2021.11.x.cfg
@@ -1,9 +1,0 @@
-[buildout]
-extends =
-    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
-    https://raw.githubusercontent.com/4teamwork/opengever.core/2021.11.0/versions.cfg
-    base-testing.cfg
-
-[test]
-eggs +=
-    unittest2

--- a/test-og-2021.12.x.cfg
+++ b/test-og-2021.12.x.cfg
@@ -1,9 +1,0 @@
-[buildout]
-extends =
-    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
-    https://raw.githubusercontent.com/4teamwork/opengever.core/2021.12.0/versions.cfg
-    base-testing.cfg
-
-[test]
-eggs +=
-    unittest2

--- a/test-og-2021.13.x.cfg
+++ b/test-og-2021.13.x.cfg
@@ -1,9 +1,0 @@
-[buildout]
-extends =
-    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
-    https://raw.githubusercontent.com/4teamwork/opengever.core/2021.13.0/versions.cfg
-    base-testing.cfg
-
-[test]
-eggs +=
-    unittest2

--- a/test-og-2021.14.x.cfg
+++ b/test-og-2021.14.x.cfg
@@ -1,9 +1,0 @@
-[buildout]
-extends =
-    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
-    https://raw.githubusercontent.com/4teamwork/opengever.core/2021.14.0/versions.cfg
-    base-testing.cfg
-
-[test]
-eggs +=
-    unittest2

--- a/test-og-2021.15.x.cfg
+++ b/test-og-2021.15.x.cfg
@@ -1,9 +1,0 @@
-[buildout]
-extends =
-    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
-    https://raw.githubusercontent.com/4teamwork/opengever.core/2021.15.0/versions.cfg
-    base-testing.cfg
-
-[test]
-eggs +=
-    unittest2

--- a/test-og-2021.16.x.cfg
+++ b/test-og-2021.16.x.cfg
@@ -1,9 +1,0 @@
-[buildout]
-extends =
-    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
-    https://raw.githubusercontent.com/4teamwork/opengever.core/2021.16.0/versions.cfg
-    base-testing.cfg
-
-[test]
-eggs +=
-    unittest2

--- a/test-og-2021.17.x.cfg
+++ b/test-og-2021.17.x.cfg
@@ -1,9 +1,0 @@
-[buildout]
-extends =
-    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
-    https://raw.githubusercontent.com/4teamwork/opengever.core/2021.17.4/versions.cfg
-    base-testing.cfg
-
-[test]
-eggs +=
-    unittest2

--- a/test-og-2021.18.x.cfg
+++ b/test-og-2021.18.x.cfg
@@ -1,9 +1,0 @@
-[buildout]
-extends =
-    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
-    https://raw.githubusercontent.com/4teamwork/opengever.core/2021.18.2/versions.cfg
-    base-testing.cfg
-
-[test]
-eggs +=
-    unittest2

--- a/test-og-2021.19.x.cfg
+++ b/test-og-2021.19.x.cfg
@@ -1,9 +1,0 @@
-[buildout]
-extends =
-    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
-    https://raw.githubusercontent.com/4teamwork/opengever.core/2021.19.0/versions.cfg
-    base-testing.cfg
-
-[test]
-eggs +=
-    unittest2

--- a/test-og-2021.3.x.cfg
+++ b/test-og-2021.3.x.cfg
@@ -1,9 +1,0 @@
-[buildout]
-extends =
-    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
-    https://raw.githubusercontent.com/4teamwork/opengever.core/2021.3.0/versions.cfg
-    base-testing.cfg
-
-[test]
-eggs +=
-    unittest2

--- a/test-og-2021.5.x.cfg
+++ b/test-og-2021.5.x.cfg
@@ -1,9 +1,0 @@
-[buildout]
-extends =
-    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
-    https://raw.githubusercontent.com/4teamwork/opengever.core/2021.5.1/versions.cfg
-    base-testing.cfg
-
-[test]
-eggs +=
-    unittest2

--- a/test-og-2021.7.x.cfg
+++ b/test-og-2021.7.x.cfg
@@ -1,9 +1,0 @@
-[buildout]
-extends =
-    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
-    https://raw.githubusercontent.com/4teamwork/opengever.core/2021.7.0/versions.cfg
-    base-testing.cfg
-
-[test]
-eggs +=
-    unittest2

--- a/test-og-2021.8.x.cfg
+++ b/test-og-2021.8.x.cfg
@@ -1,9 +1,0 @@
-[buildout]
-extends =
-    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
-    https://raw.githubusercontent.com/4teamwork/opengever.core/2021.8.0/versions.cfg
-    base-testing.cfg
-
-[test]
-eggs +=
-    unittest2

--- a/test-og-2021.9.x.cfg
+++ b/test-og-2021.9.x.cfg
@@ -1,9 +1,0 @@
-[buildout]
-extends =
-    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
-    https://raw.githubusercontent.com/4teamwork/opengever.core/2021.9.0/versions.cfg
-    base-testing.cfg
-
-[test]
-eggs +=
-    unittest2


### PR DESCRIPTION
We do not have any real deployment on a version older than 2021.21.

For https://4teamwork.atlassian.net/browse/CA-5655