### PR TITLE
Improve script to import propertysheets

### DIFF
--- a/opengever/maintenance/scripts/add_propertysheets.py
+++ b/opengever/maintenance/scripts/add_propertysheets.py
@@ -46,6 +46,7 @@ def add_propertysheets(filepath, clear_storage=False):
 
             description = field_data.get("description", u"")
             required = field_data.get("required", False)
+            available_as_docproperty = field_data.get("available_as_docproperty", False)
             default = field_data.get("default", None)
             if default:
                 if not isinstance(default, unicode):
@@ -61,7 +62,9 @@ def add_propertysheets(filepath, clear_storage=False):
 
             schema_definition.add_field(
                 field_type, name, label, description, required,
-                values, default=default)
+                values=values,
+                available_as_docproperty=available_as_docproperty,
+                default=default)
 
         storage.save(schema_definition)
 

--- a/opengever/maintenance/scripts/add_propertysheets.py
+++ b/opengever/maintenance/scripts/add_propertysheets.py
@@ -9,12 +9,13 @@
 from opengever.maintenance.debughelpers import setup_app
 from opengever.maintenance.debughelpers import setup_option_parser
 from opengever.maintenance.debughelpers import setup_plone
+from opengever.maintenance.utils import JsonReferencesResolver
 from opengever.propertysheets.definition import PropertySheetSchemaDefinition
 from opengever.propertysheets.storage import PropertySheetSchemaStorage
+import json
 import logging
 import sys
 import transaction
-import json
 
 
 logger = logging.getLogger('opengever.maintenance')
@@ -31,6 +32,7 @@ def add_propertysheets(filepath, clear_storage=False):
 
     with open(filepath) as sheets_file:
         sheets = json.load(sheets_file)
+        sheets = JsonReferencesResolver(sheets)()
 
     for sheet in sheets:
         schema_definition = PropertySheetSchemaDefinition.create(

--- a/opengever/maintenance/scripts/add_propertysheets.py
+++ b/opengever/maintenance/scripts/add_propertysheets.py
@@ -51,7 +51,7 @@ def add_propertysheets(filepath, clear_storage=False):
             available_as_docproperty = field_data.get("available_as_docproperty", False)
             default = field_data.get("default", None)
             if default:
-                if not isinstance(default, unicode):
+                if isinstance(default, str):
                     value = default.decode('utf-8')
 
             values = []


### PR DESCRIPTION
With this PR we alle the use of references in the json file defining the propertysheets that are imported using the `opengever/maintenance/scripts/add_propertysheets.py` script. We also make a few other improvements in the script.

For https://4teamwork.atlassian.net/browse/CA-5768