### PR TITLE
Speedup group migration

### DIFF
--- a/opengever/maintenance/scripts/migrate_groups.py
+++ b/opengever/maintenance/scripts/migrate_groups.py
@@ -70,6 +70,7 @@ class LocalRolesUpdater(object):
             self.include_tasks = False
         self.log = []
         self.orgunits_with_modified_inbox_group = []
+        self.catalog = api.portal.get_tool('portal_catalog')
 
     def check_preconditions(self):
         for org_unit in OrgUnit.query:
@@ -103,7 +104,6 @@ class LocalRolesUpdater(object):
     def analyse(self):
         self.check_preconditions()
 
-        self.catalog = api.portal.get_tool('portal_catalog')
         # We only need to check repositoryroots, -folders, dossiers,
         # tasktemplates, tasktemplatefolders, proposals and dispositions.
         # Because all these groups are not used as a org_unit group or inbox_group,

--- a/opengever/maintenance/scripts/migrate_groups.py
+++ b/opengever/maintenance/scripts/migrate_groups.py
@@ -209,8 +209,6 @@ class LocalRolesUpdater(object):
             self.log.append(('/'.join(obj.getPhysicalPath()), changes))
             logger.info("updating {}".format(self.log[-1][0]))
             manager._update_local_roles()
-            if ITask.providedBy(obj):
-                obj.sync()
             if self.options.immediate_commits and not self.options.dryrun:
                 transaction.commit()
 


### PR DESCRIPTION
With this PR we massively speed up the group migration by avoiding the use of `reindexObjectSecurity`. Instead we directly modify the security indexes in plone and in solr, as a group migration is basically a search and replace in those indexes.

For the HBA migration update of the index took around 40 seconds, whereas we never found out how long `reindexObjectSecurity` would take as it never finished, but from discussions with @lukasgraf it seems that even when reindexing just one branch of the repository (the largest branch), reindexing the object security did not finish in a whole weekend.

For https://4teamwork.atlassian.net/browse/CA-5829