### PR TITLE
Group migration should also work on teamraum deployments.

### DIFF
--- a/opengever/maintenance/scripts/migrate_groups.py
+++ b/opengever/maintenance/scripts/migrate_groups.py
@@ -45,6 +45,8 @@ from opengever.repository.repositoryroot import IRepositoryRoot
 from opengever.task.task import ITask
 from opengever.tasktemplates.content.tasktemplate import ITaskTemplate
 from opengever.tasktemplates.content.templatefoldersschema import ITaskTemplateFolderSchema
+from opengever.workspace.interfaces import IWorkspace
+from opengever.workspace.interfaces import IWorkspaceFolder
 from plone import api
 from zope.component import queryUtility
 import argparse
@@ -130,6 +132,8 @@ class LocalRolesUpdater(object):
                 IContactFolder.__identifier__,
                 IInboxContainer.__identifier__,
                 IInbox.__identifier__,
+                IWorkspace.__identifier__,
+                IWorkspaceFolder.__identifier__,
                 ]
         if self.include_tasks:
             interfaces_to_update.append(ITask.__identifier__)


### PR DESCRIPTION
Because the Gever groups are also used in Teamraum, we need to also migrate the groups in a linked teamraum deployment whenever we migrate the groups in a Gever deployment.

For https://4teamwork.atlassian.net/browse/CA-6223