### PR TITLE
Make export_and_close_dossiers.py more failsafe

### DIFF
--- a/opengever/maintenance/scripts/export_and_close_dossiers.py
+++ b/opengever/maintenance/scripts/export_and_close_dossiers.py
@@ -12,6 +12,7 @@ from opengever.maintenance.debughelpers import setup_plone
 from opengever.maintenance.utils import LogFilePathFinder
 from opengever.maintenance.utils import TextTable
 from opengever.repository.interfaces import IRepositoryFolder
+from opengever.trash.trash import ITrashed
 from opengever.workspaceclient.interfaces import IWorkspaceClientSettings
 from plone import api
 from zope.component import getAdapter
@@ -189,6 +190,10 @@ class DossierExporter(object):
                 object_provides=IBaseDocument.__identifier__)
         for brain in res:
             doc = brain.getObject()
+            if ITrashed.providedBy(doc):
+                logger.info("Skipped trashed document: {}".format(doc.absolute_url_path()))
+                continue
+
             file_ = doc.get_file()
             if not file_:
                 logger.info("Skipped document without file: {}".format(doc.absolute_url_path()))

--- a/opengever/maintenance/scripts/export_and_close_dossiers.py
+++ b/opengever/maintenance/scripts/export_and_close_dossiers.py
@@ -189,9 +189,14 @@ class DossierExporter(object):
                 object_provides=IBaseDocument.__identifier__)
         for brain in res:
             doc = brain.getObject()
+            file_ = doc.get_file()
+            if not file_:
+                logger.info("Skipped document without file: {}".format(doc.absolute_url_path()))
+                continue
+
             filename, ext = os.path.splitext(doc.get_filename())
             file_path = self._get_output_path(folder_path, filename, ext)
-            shutil.copy2(doc.file._blob.committed(), file_path)
+            shutil.copy2(file_._blob.committed(), file_path)
 
     def log_and_write_table(self, brains, title, filename):
         table = TextTable()


### PR DESCRIPTION
This PR updates the [export_and_close_dossiers.py](https://github.com/4teamwork/opengever.maintenance/compare/es/CA-5982-export-kita-dossiers-muri?expand=1#diff-de1377f892f5a10770eeabada479a4f7e5c22fc6549444f1438a01ff1ad558c3) script to make it more failsafe.

Required for: https://4teamwork.atlassian.net/browse/CA-5982

[CA-5982]