### PR TITLE
Improve metadata update handling in repository_migration script.

### DIFF
--- a/opengever/maintenance/scripts/repository_migration.py
+++ b/opengever/maintenance/scripts/repository_migration.py
@@ -1369,7 +1369,7 @@ class RepositoryMigrator(MigratorBase):
             # We do not need to reindex path as this seems to already happen
             # recursively
             self.add_to_reindexing_queue(
-                item['uid'], ('Title', 'sortable_title'))
+                item['uid'], ('Title', 'title_de', 'title_fr', 'title_en', 'sortable_title'))
             if not self.dry_run:
                 transaction.commit()
 
@@ -1433,7 +1433,10 @@ class RepositoryMigrator(MigratorBase):
             if not obj:
                 logger.error("Could not find {} to reindex. Skipping".format(uid))
                 continue
-            obj.reindexObject(idxs=idxs)
+
+            # WARNING! idxs needs to be a tuple, otherwise solr will always update all attributes
+            # See: https://github.com/plone/collective.indexing/blob/2.0/src/collective/indexing/queue.py#L142
+            obj.reindexObject(idxs=tuple(idxs))
             if obj.portal_type == 'opengever.task.task':
                 # make sure that the model is up to date.
                 TaskSqlSyncer(obj, None).sync()


### PR DESCRIPTION
We improve the performance and allow to have no blobs when indexing by patching the Catalog and only updating relevant metadata instead the full list of metadata.

The Catalog will always update all available metadata if reindexing an object with `update_metadata` enabled. There is no way to update only specific metadata values of an object. Updating metadata means, that all metadata will be recalcuated for an objects. This process takes a lot of time and is mostly unnecessary. In addition, it requires to have access to the blobs of documents because some of the metadata properties are relying on blob information (filesize). To speed up the migration and to be able to run the migration without the existence of blobs, we'll patch the catalog to only update the relevant metadata items.