### PR TITLE
Fix intergever URL for sgprod

### DIFF
--- a/opengever/maintenance/scripts/connect_to_intergever.py
+++ b/opengever/maintenance/scripts/connect_to_intergever.py
@@ -32,7 +32,7 @@ CLUSTERS = {
     },
     "sgprod": {
         "gever_base_url": "https://gever.sg.ch",
-        "intergever_url": "https://gever.sg.ch/intergever",
+        "intergever_url": "https://intergever.sg.ch/",
     },
     "oggdev": {
         "gever_base_url": "https://dev.onegovgever.ch/",


### PR DESCRIPTION
Add 'sgprod' cluster to connect_to_intergever.py

For [HG-4496](https://4teamwork.atlassian.net/browse/HG-4496)

[HG-4496]: https://4teamwork.atlassian.net/browse/HG-4496?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ