### PR TITLE
Add maintenance script: fix_broken_intid_references

### DIFF
--- a/opengever/maintenance/scripts/fix_broken_intid_references.py
+++ b/opengever/maintenance/scripts/fix_broken_intid_references.py
@@ -1,0 +1,168 @@
+"""
+Script to fix broken intid references.
+
+    bin/instance run ./scripts/fix_broken_intid_references.py [-n] --check --fix
+
+or with separate check and fix:
+
+   bin/instance run ./scripts/fix_broken_intid_references.py --check -o ./fix-ids
+   bin/instance run ./scripts/fix_broken_intid_references.py --fix -o ./fix-ids
+
+The --check will create a json file (and a backup of it) with all broken object paths
+within the output directory.
+The --fix will then read these paths and fix each object. It will commit the transaction
+every few items and will update the the json with the remeaing items.
+"""
+from five.intid.intid import moveIntIdSubscriber
+from ftw.upgrade.progresslogger import ProgressLogger
+from opengever.maintenance.debughelpers import setup_app
+from opengever.maintenance.debughelpers import setup_option_parser
+from opengever.maintenance.debughelpers import setup_plone
+from plone import api
+from zope.component import getUtility
+from zope.intid import IIntIds
+import json
+import logging
+import os
+import sys
+import time
+import transaction
+
+logger = logging.getLogger('opengever.maintenance')
+handler = logging.StreamHandler(stream=sys.stdout)
+handler.setFormatter(logging.Formatter('%(levelname)s %(message)s'))
+logging.root.addHandler(handler)
+logging.root.setLevel(logging.INFO)
+
+
+class IntIdReferenceFixer(object):
+
+    def __init__(self, portal, dry_run, working_dir):
+        self.portal = portal
+        self.dry_run = dry_run
+        self.working_dir = working_dir
+        self.catalog = api.portal.get_tool('portal_catalog')
+        self.intid_utility = getUtility(IIntIds)
+        self.objs_to_fix_path = os.path.join(working_dir, 'objs_to_fix.json')
+
+    def check(self):
+        broken = []
+        for brain in ProgressLogger(
+                'Checking for broken intid references',
+                self.catalog.unrestrictedSearchResults(),
+                logger=logger):
+            obj = brain.getObject()
+            ref = self.intid_utility.refs.get(self.intid_utility.getId(obj))
+            obj_path = '/'.join(obj.getPhysicalPath())
+            if obj_path != ref.path:
+                broken.append(obj_path)
+                logger.info("Found broken object: {}".format(obj_path))
+
+        if not broken:
+            logger.info("Nothing is broken.")
+        else:
+            logger.info("{} objects are broken.".format(len(broken)))
+
+        logger.info("Writing broken paths to: {}".format(self.objs_to_fix_path))
+
+        self.write_broken_paths(broken, self.objs_to_fix_path)
+        self.write_broken_paths(broken, self.objs_to_fix_path + '.backup')
+
+    def fix(self, commit_every=100):
+        logger.info("Loading broken paths from: {}".format(objs_to_fix_path))
+        broken = self.load_broken_paths(self.objs_to_fix_path)
+
+        if not broken:
+            logger.info("There is nothing to fix.")
+            return
+
+        fixed = []
+        for index, brain in enumerate(ProgressLogger(
+                'Fixing broken intid references',
+                self.catalog.unrestrictedSearchResults(path={'query': broken, 'depth': 0}),
+                logger=logger)):
+
+            moveIntIdSubscriber(brain.getObject(), None)
+            fixed.append(brain.getPath())
+
+            if index > 0 and index % commit_every == 0:
+                self.commit_fixes(broken, fixed)
+        self.commit_fixes(broken, fixed)
+
+    def write_broken_paths(self, broken, path):
+        with open(path, "w") as file_:
+            json.dump(tuple(broken), file_)
+
+    def load_broken_paths(self, path):
+        with open(path, "r") as file_:
+            return json.load(file_)
+
+    def commit_fixes(self, broken, fixed):
+        if self.dry_run:
+            return
+
+        logger.info("Committing transaction and removing already fixed objects from the file: {}".format(
+            self.objs_to_fix_path))
+
+        transaction.commit()
+        remaining = list(set(broken).difference(set(fixed)))
+        self.write_broken_paths(remaining, self.objs_to_fix_path)
+
+    def validate(self):
+        logger.info("Starting validation checks...")
+        broken = self.load_broken_paths(self.objs_to_fix_path)
+        if len(broken):
+            logger.error("There are still broken objects. See: {}".format(self.objs_to_fix_path))
+        else:
+            logger.info("Everything processed and fixed.")
+
+
+if __name__ == '__main__':
+    app = setup_app()
+
+    parser = setup_option_parser()
+    parser.add_option("-n", "--dry-run", action="store_true",
+                      help="Dry run")
+    parser.add_option("--check", action="store_true",
+                      help="Check for broken ids")
+    parser.add_option("--fix", action="store_true",
+                      help="Fix broken ids")
+    parser.add_option(
+        '-o', dest='output_directory',
+        default='var/maintenance-fix-broken-intid-references-{}'.format(
+            time.strftime('%d%m%Y-%H%M%S')),
+        help='Path to the output directory')
+    (options, args) = parser.parse_args()
+
+    objs_to_fix_path = os.path.join(
+        options.output_directory, 'objs_to_fix.json')
+
+    logger.info("Using the following output directory: {}".format(options.output_directory))
+
+    if not options.output_directory:
+        logger.info("Invalid output directory")
+        sys.exit(1)
+
+    if os.path.isdir(options.output_directory):
+        logger.warn("Output directory already exists. Content will be replaced")
+    else:
+        logger.info("Creating output directory")
+        os.mkdir(options.output_directory)
+
+    if options.dry_run:
+        logger.info("DRY RUN")
+        transaction.doom()
+
+    plone = setup_plone(app, options)
+    fixer = IntIdReferenceFixer(
+        plone,
+        dry_run=options.dry_run,
+        working_dir=options.output_directory)
+
+    if options.check:
+        fixer.check()
+
+    if options.fix:
+        fixer.fix()
+
+    fixer.validate()


### PR DESCRIPTION
For: https://4teamwork.atlassian.net/browse/TI-23

This PR adds a new script to fix broken intid references.

In a first step, script will gather all broken objects and write the paths into a json file. In a second step, the script will fix those paths. So it's also possible to directly fix some specific objects without previously run a full check.

```shell
bin/instance run ./scripts/fix_broken_intid_references.py --check --fix
INFO Use the following output directory: var/maintenance-fix-broken-intid-references-22042024-143427
INFO Create output directory
INFO: Using Plone Site 'fd'.
INFO STARTING Check for broken intid references
INFO Found broken object: /fd/private
INFO 1 of 237 (0%): Check for broken intid references
INFO Found broken object: /fd/eingangskorb
...
INFO DONE Check for broken intid references
INFO 237 objects are broken.
INFO Write broken paths to: var/maintenance-fix-broken-intid-references-22042024-143427/objs_to_fix.json
INFO Load broken paths from: var/maintenance-fix-broken-intid-references-22042024-143427/objs_to_fix.json
INFO STARTING Fix broken intid references
INFO 1 of 237 (0%): Fix broken intid references
INFO Committing transaction and remove already fixed objects from the file: var/maintenance-fix-broken-intid-references-22042024-143427/objs_to_fix.json
INFO Committing transaction and remove already fixed objects from the file: var/maintenance-fix-broken-intid-references-22042024-143427/objs_to_fix.json
INFO DONE Fix broken intid references
INFO Committing transaction and remove already fixed objects from the file: var/maintenance-fix-broken-intid-references-22042024-143427/objs_to_fix.json
INFO Starting validation checks...
INFO Everything processed and fixed.
INFO DONE Pre-cooking 737 templates.
```

Here are some additional information about debugging the issue:

```python
>>> context = plone.unrestrictedTraverse('/root/path/container/content')
>>> '/'.join(context.getPhysicalPath())
'/root/path/container/content'
>>> IKeyReference(context).path
'/root/path/container/content'
>>> intid_ref = intid.refs.get(intid.getId(context))
>>> intid_ref
<five.intid.keyreference.KeyReferenceToPersistent object at 0x4f9628927790>
>>> intid_ref.path
'/root/path/container-old/content'
>>> intid_ref()
Traceback (most recent call last):
  File "<console>", line 1, in <module>
  File "/home/xxx/eggs/zope.intid-3.7.2-py2.7.egg/zope/intid/__init__.py", line 72, in getObject
    return self.refs[id]()
  File "/home/xxx/eggs/five.intid-1.0.3-py2.7.egg/five/intid/keyreference.py", line 124, in __call__
    return self.wrapped_object
  File "/home/xxx/eggs/five.intid-1.0.3-py2.7.egg/five/intid/keyreference.py", line 104, in wrapped_object
    obj = self.root.unrestrictedTraverse(self.path)
  File "/home/xxx/eggs/Zope2-2.13.30-py2.7.egg/OFS/Traversable.py", line 300, in unrestrictedTraverse
    raise e
KeyError: 'container-old'
```

the key-reference will updated during add, remove or renaming an object:

``` traceback
/Users/foo/projects/opengever.core/src/opengever.maintenance/opengever/maintenance/scripts/update_object_ids.py(139)update_object_id()
-> obj = api.content.rename(self.obj, new_id)
  <string>(2)rename()
  /Users/foo/Plone/eggs/plone.api-1.10.2-py2.7.egg/plone/api/validation.py(81)wrapped()
-> return function(*args, **kwargs)
  /Users/foo/Plone/eggs/plone.api-1.10.2-py2.7.egg/plone/api/content.py(234)rename()
-> container.manage_renameObject(obj_id, new_id)
  /Users/foo/Plone/eggs/plone.folder-1.0.12-py2.7.egg/plone/folder/ordered.py(193)manage_renameObject()
-> REQUEST
  /Users/foo/Plone/eggs/Zope2-2.13.30-py2.7.egg/OFS/CopySupport.py(417)manage_renameObject()
-> notify(ObjectMovedEvent(ob, self, id, self, new_id))
  /Users/foo/Plone/eggs/zope.event-3.5.2-py2.7.egg/zope/event/__init__.py(31)notify()
-> subscriber(event)
  /Users/foo/Plone/eggs/zope.component-3.9.5-py2.7.egg/zope/component/event.py(24)dispatch()
-> zope.component.subscribers(event, None)
  /Users/foo/Plone/eggs/zope.component-3.9.5-py2.7.egg/zope/component/_api.py(136)subscribers()
-> return sitemanager.subscribers(objects, interface)
  /Users/foo/Plone/eggs/zope.component-3.9.5-py2.7.egg/zope/component/registry.py(321)subscribers()
-> return self.adapters.subscribers(objects, provided)
  /Users/foo/Plone/eggs/zope.interface-3.6.7-py2.7-macosx-10.4-x86_64.egg/zope/interface/adapter.py(585)subscribers()
-> subscription(*objects)
  /Users/foo/Plone/eggs/zope.component-3.9.5-py2.7.egg/zope/component/event.py(32)objectEventNotify()
-> zope.component.subscribers((event.object, event), None)
  /Users/foo/Plone/eggs/zope.component-3.9.5-py2.7.egg/zope/component/_api.py(136)subscribers()
-> return sitemanager.subscribers(objects, interface)
  /Users/foo/Plone/eggs/zope.component-3.9.5-py2.7.egg/zope/component/registry.py(321)subscribers()
-> return self.adapters.subscribers(objects, provided)
  /Users/foo/Plone/eggs/zope.interface-3.6.7-py2.7-macosx-10.4-x86_64.egg/zope/interface/adapter.py(585)subscribers()
-> subscription(*objects)
  /Users/foo/Plone/eggs/Zope2-2.13.30-py2.7.egg/OFS/subscribers.py(113)dispatchObjectMovedEvent()
-> dispatchToSublocations(ob, event)
  /Users/foo/Plone/eggs/zope.container-3.11.2-py2.7-macosx-10.4-x86_64.egg/zope/container/contained.py(153)dispatchToSublocations()
-> for ignored in zope.component.subscribers((sub, event), None):
  /Users/foo/Plone/eggs/zope.component-3.9.5-py2.7.egg/zope/component/_api.py(136)subscribers()
-> return sitemanager.subscribers(objects, interface)
  /Users/foo/Plone/eggs/zope.component-3.9.5-py2.7.egg/zope/component/registry.py(321)subscribers()
-> return self.adapters.subscribers(objects, provided)
  /Users/foo/Plone/eggs/zope.interface-3.6.7-py2.7-macosx-10.4-x86_64.egg/zope/interface/adapter.py(585)subscribers()
-> subscription(*objects)
  /Users/foo/Plone/eggs/five.intid-1.0.3-py2.7.egg/five/intid/intid.py(141)moveIntIdSubscriber()
-> key = IKeyReference(ob, None)
  /Users/foo/Plone/eggs/zope.component-3.9.5-py2.7.egg/zope/component/hooks.py(104)adapter_hook()
-> return siteinfo.adapter_hook(interface, object, name, default)
  /Users/foo/Plone/eggs/zope.security-3.7.4-py2.7-macosx-10.4-x86_64.egg/zope/security/adapter.py(88)__call__()
-> adapter = self.factory(*args)
  /Users/foo/Plone/eggs/five.intid-1.0.3-py2.7.egg/five/intid/keyreference.py(62)__init__()
-> self.path = '/'.join(wrapped_obj.getPhysicalPath())
> /Users/foo/Plone/eggs/five.intid-1.0.3-py2.7.egg/five/intid/keyreference.py(95)__setattr__()
-> super(KeyReferenceToPersistent, self).__setattr__(name, value)
```